### PR TITLE
Bugfix

### DIFF
--- a/includes/class-klarna-checkout-for-woocommerce-order-lines.php
+++ b/includes/class-klarna-checkout-for-woocommerce-order-lines.php
@@ -123,7 +123,7 @@ class Klarna_Checkout_For_WooCommerce_Order_Lines {
 			}
 		}
 		foreach ( WC()->cart->get_applied_coupons() as $coupon ) {
-			$merchant_data                                      = json_decode( Klarna_Checkout_For_WooCommerce_API::$merchant_data );
+			$merchant_data                                      = json_decode( Klarna_Checkout_For_WooCommerce_API::$merchant_data, true );
 			$merchant_data['coupons'][]                         = $coupon;
 			Klarna_Checkout_For_WooCommerce_API::$merchant_data = json_encode( $merchant_data );
 		}


### PR DESCRIPTION
This fixes a crash when using more than 1 coupon code.

The first itteration of the loop will be an empty string and the json_decode will parse the empty string as null.
And when you modify the $merchant_data as an array on null, it will be cast to a valid array.

But when you json_decode the next time json_decode will cast the json string to an object and not an array, when you try to modify the json object as an array (line 128) this causes a php fatal error.

Added true as the second parameter to decode as an array rather than an object.