### PR TITLE
1.9.3

### DIFF
--- a/includes/class-klarna-checkout-for-woocommerce-api.php
+++ b/includes/class-klarna-checkout-for-woocommerce-api.php
@@ -495,76 +495,7 @@ class Klarna_Checkout_For_WooCommerce_API {
 	 * @return string
 	 */
 	public function get_purchase_locale() {
-
-		if ( defined( 'ICL_LANGUAGE_CODE' ) ) {
-			$locale = ICL_LANGUAGE_CODE;
-		} else {
-			$locale = explode( '_', get_locale() );
-			$locale = $locale[0];
-		}
-
-		switch ( WC()->checkout()->get_value( 'billing_country' ) ) {
-			case 'AT':
-				if ( 'de' == $locale ) {
-					$klarna_locale = 'de-at';
-				} else {
-					$klarna_locale = 'en-at';
-				}
-				break;
-			case 'DE':
-				if ( 'de' == $locale ) {
-					$klarna_locale = 'de-de';
-				} else {
-					$klarna_locale = 'en-de';
-				}
-				break;
-			case 'DK':
-				if ( 'da' == $locale ) {
-					$klarna_locale = 'da-dk';
-				} else {
-					$klarna_locale = 'en-dk';
-				}
-				break;
-			case 'FI':
-				if ( 'fi' == $locale ) {
-					$klarna_locale = 'fi-fi';
-				} elseif ( 'sv' == $locale ) {
-					$klarna_locale = 'sv-fi';
-				} else {
-					$klarna_locale = 'en-fi';
-				}
-				break;
-			case 'NL':
-				if ( 'nl' == $locale ) {
-					$klarna_locale = 'nl-nl';
-				} else {
-					$klarna_locale = 'en-nl';
-				}
-				break;
-			case 'NO':
-				if ( 'nb' == $locale || 'nn' == $locale || 'no' == $locale ) {
-					$klarna_locale = 'nb-no';
-				} else {
-					$klarna_locale = 'en-no';
-				}
-				break;
-			case 'SE':
-				if ( 'sv' == $locale || 'sv_se' == $locale ) {
-					$klarna_locale = 'sv-se';
-				} else {
-					$klarna_locale = 'en-se';
-				}
-				break;
-			case 'GB':
-				$klarna_locale = 'en-gb';
-				break;
-			case 'US':
-				$klarna_locale = 'en-us';
-				break;
-			default:
-				$klarna_locale = 'en-us';
-		} // End switch().
-
+		$klarna_locale = str_replace( '_', '-', get_locale() );
 		return $klarna_locale;
 	}
 

--- a/includes/class-klarna-checkout-for-woocommerce-templates.php
+++ b/includes/class-klarna-checkout-for-woocommerce-templates.php
@@ -50,7 +50,6 @@ class Klarna_Checkout_For_WooCommerce_Templates {
 	 *
 	 * @param string $template      Template.
 	 * @param string $template_name Template name.
-	 * @param string $template_path Template path.
 	 *
 	 * @return string
 	 */

--- a/klarna-checkout-for-woocommerce.php
+++ b/klarna-checkout-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Klarna Checkout payment gateway for WooCommerce.
  * Author: Krokedil
  * Author URI: https://krokedil.com/
- * Version: 1.9.2
+ * Version: 1.9.3
  * Text Domain: klarna-checkout-for-woocommerce
  * Domain Path: /languages
  *
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'KCO_WC_VERSION', '1.9.2' );
+define( 'KCO_WC_VERSION', '1.9.3' );
 define( 'KCO_WC_MIN_PHP_VER', '5.6.0' );
 define( 'KCO_WC_MIN_WC_VER', '3.0.0' );
 define( 'KCO_WC_MAIN_FILE', __FILE__ );

--- a/klarna-checkout-for-woocommerce.php
+++ b/klarna-checkout-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Klarna Checkout payment gateway for WooCommerce.
  * Author: Krokedil
  * Author URI: https://krokedil.com/
- * Version: 1.9.1
+ * Version: 1.9.2
  * Text Domain: klarna-checkout-for-woocommerce
  * Domain Path: /languages
  *
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'KCO_WC_VERSION', '1.9.1' );
+define( 'KCO_WC_VERSION', '1.9.2' );
 define( 'KCO_WC_MIN_PHP_VER', '5.6.0' );
 define( 'KCO_WC_MIN_WC_VER', '3.0.0' );
 define( 'KCO_WC_MAIN_FILE', __FILE__ );

--- a/readme.txt
+++ b/readme.txt
@@ -63,6 +63,11 @@ For help setting up and configuring Klarna Payments for WooCommerce please refer
 
 == Changelog ==
 
+= 2019.04.18  	- version 1.9.2 =
+* Fix           - Only set autoResume = false when suspending KCO iframe during required extra checkout fields check. Otherwise keep it to 10 seconds.
+* Fix           - Don't redirect customer in check_that_kco_template_has_loaded function if user is not logged and registration is disabled.
+* Fix           - Organization name and address line 2 no longer dependenat on billing address for the shipping address to be added.
+
 = 2019.04.05  	- version 1.9.1 =
 * Tweak         - Added check to see if validate-required form row contains input field (in extra checkout field handling).
 * Tweak         - Retain error notice regarding required checkout fields needs to be entered after updated_checkout event has triggered.

--- a/readme.txt
+++ b/readme.txt
@@ -63,6 +63,10 @@ For help setting up and configuring Klarna Payments for WooCommerce please refer
 
 == Changelog ==
 
+= 2019.04.30  	- version 1.9.3 =
+* Fix           - Changed filter to wc_get_template for overriding checkout template (props @forsvunnet).
+* Fix           - Improved logic in locale sent to Klarna. Fixes WC 3.6 bug where English where displayed as default lang in some stores. 
+
 = 2019.04.18  	- version 1.9.2 =
 * Fix           - Only set autoResume = false when suspending KCO iframe during required extra checkout fields check. Otherwise keep it to 10 seconds.
 * Fix           - Don't redirect customer in check_that_kco_template_has_loaded function if user is not logged and registration is disabled.


### PR DESCRIPTION
* Fix - Changed filter to wc_get_template for overriding checkout template (props @forsvunnet).
* Fix - Improved logic in locale sent to Klarna. Fixes WC 3.6 bug where English where displayed as default lang in some stores. 
