### PR TITLE
Add response code / status message in case error message is empty

### DIFF
--- a/includes/class-klarna-checkout-for-woocommerce-api.php
+++ b/includes/class-klarna-checkout-for-woocommerce-api.php
@@ -112,7 +112,7 @@ class Klarna_Checkout_For_WooCommerce_API {
 			$url = add_query_arg(
 				array(
 					'kco-order' => 'error',
-					'reason'    => base64_encode( $error->get_error_message() ),
+					'reason'    => base64_encode( $error->get_error_message() ? $error->get_error_message() : $response['response']['code'] . " " . $response['response']['message'] ),
 				),
 				wc_get_cart_url()
 			);


### PR DESCRIPTION
I got an empty error message "An error occurred during communication with Klarna ().", with this change, at least I get "An error occurred during communication with Klarna (403 Forbidden)."