### PR TITLE
Fix for navigating to checkout with a product out of stock

### DIFF
--- a/includes/class-klarna-checkout-for-woocommerce-templates.php
+++ b/includes/class-klarna-checkout-for-woocommerce-templates.php
@@ -127,8 +127,8 @@ class Klarna_Checkout_For_WooCommerce_Templates {
 
 			// Get checkout object.
 			$checkout = WC()->checkout();
-			// Bail if this is KCO confirmation page, order received page, KCO page (kco_wc_show_snippet has run) or user is not logged and registration is disabled.
-			if ( is_kco_confirmation() || is_wc_endpoint_url( 'order-received' ) || did_action( 'kco_wc_show_snippet' ) || ( ! $checkout->is_registration_enabled() && $checkout->is_registration_required() && ! is_user_logged_in() ) ) {
+			// Bail if this is KCO confirmation page, order received page, KCO page (kco_wc_show_snippet has run), user is not logged and registration is disabled or if woocommerce_cart_has_errors has run.
+			if ( is_kco_confirmation() || is_wc_endpoint_url( 'order-received' ) || did_action( 'kco_wc_show_snippet' ) || ( ! $checkout->is_registration_enabled() && $checkout->is_registration_required() && ! is_user_logged_in() ) || did_action( 'woocommerce_cart_has_errors' ) ) {
 				return;
 			}
 


### PR DESCRIPTION
"Failed to load Klarna Checkout template file" error will not be rendered if the action "woocommerce_cart_has_errors" ran. #230