### PR TITLE
Bugg fix for home_url on merchant urls

### DIFF
--- a/includes/class-klarna-checkout-for-woocommerce-merchant-urls.php
+++ b/includes/class-klarna-checkout-for-woocommerce-merchant-urls.php
@@ -80,7 +80,14 @@ class Klarna_Checkout_For_WooCommerce_Merchant_URLs {
 	 */
 	private function get_push_url() {
 		$session_id = $this->get_session_id();
-		$push_url   = get_home_url() . '/wc-api/KCO_WC_Push/?kco-action=push&kco_wc_order_id={checkout.order.id}&kco_session_id=' . $session_id;
+
+		$push_url = home_url(
+			sprintf(
+				'/wc-api/KCO_WC_Push/?kco-action=push&kco_wc_order_id={checkout.order.id}&kco_session_id=%s',
+				$session_id
+			)
+		);
+
 		return $push_url;
 	}
 
@@ -93,7 +100,14 @@ class Klarna_Checkout_For_WooCommerce_Merchant_URLs {
 	 */
 	private function get_validation_url() {
 		$session_id     = $this->get_session_id();
-		$validation_url = get_home_url() . '/wc-api/KCO_WC_Validation/?kco-action=validation&kco_wc_order_id={checkout.order.id}&kco_session_id=' . $session_id;
+
+		$validation_url = home_url(
+			sprintf(
+				'/wc-api/KCO_WC_Validation/?kco-action=validation&kco_wc_order_id={checkout.order.id}&kco_session_id=%s',
+				$session_id
+			)
+		);
+
 		return str_replace( 'http:', 'https:', $validation_url );
 	}
 
@@ -105,7 +119,7 @@ class Klarna_Checkout_For_WooCommerce_Merchant_URLs {
 	 * @return string
 	 */
 	private function get_shipping_option_update_url() {
-		$shipping_option_update_url = get_home_url() . '/wc-api/KCO_WC_Shipping_Option_Update/';
+		$shipping_option_update_url = home_url('/wc-api/KCO_WC_Shipping_Option_Update/');
 		return str_replace( 'http:', 'https:', $shipping_option_update_url );
 	}
 
@@ -117,7 +131,7 @@ class Klarna_Checkout_For_WooCommerce_Merchant_URLs {
 	 * @return string
 	 */
 	private function get_address_update_url() {
-		$address_update_url = get_home_url() . '/wc-api/KCO_WC_Address_Update/?kco_wc_order_id={checkout.order.id}';
+		$address_update_url = home_url('/wc-api/KCO_WC_Address_Update/?kco_wc_order_id={checkout.order.id}');
 		return str_replace( 'http:', 'https:', $address_update_url );
 	}
 
@@ -129,7 +143,7 @@ class Klarna_Checkout_For_WooCommerce_Merchant_URLs {
 	 * @return string
 	 */
 	private function get_notification_url() {
-		$notification_url = get_home_url() . '/wc-api/KCO_WC_Notification/?kco_wc_order_id={checkout.order.id}';
+		$notification_url = home_url('/wc-api/KCO_WC_Notification/?kco_wc_order_id={checkout.order.id}');
 		return $notification_url;
 	}
 
@@ -141,7 +155,7 @@ class Klarna_Checkout_For_WooCommerce_Merchant_URLs {
 	 * @return string
 	 */
 	private function get_country_change_url() {
-		$country_change_url = get_home_url() . '/wp-json/kcowc/v1/address/{checkout.order.id}';
+		$country_change_url = home_url('/wp-json/kcowc/v1/address/{checkout.order.id}');
 		return str_replace( 'http:', 'https:', $country_change_url );
 	}
 

--- a/includes/class-klarna-checkout-for-woocommerce-merchant-urls.php
+++ b/includes/class-klarna-checkout-for-woocommerce-merchant-urls.php
@@ -27,7 +27,8 @@ class Klarna_Checkout_For_WooCommerce_Merchant_URLs {
 			// 'country_change'         => $this->get_country_change_url(),         // HTTPS.
 		);
 
-		return $merchant_urls;
+		return apply_filters('kco_wc_merchant_urls', $merchant_urls);
+
 	}
 
 	/**
@@ -39,7 +40,8 @@ class Klarna_Checkout_For_WooCommerce_Merchant_URLs {
 	 */
 	private function get_terms_url() {
 		$terms_url = get_permalink( wc_get_page_id( 'terms' ) );
-		return $terms_url;
+
+		return apply_filters('kco_wc_terms_url', $terms_url);
 	}
 
 	/**
@@ -51,7 +53,7 @@ class Klarna_Checkout_For_WooCommerce_Merchant_URLs {
 	 */
 	private function get_checkout_url() {
 		$checkout_url = wc_get_checkout_url();
-		return $checkout_url;
+		return apply_filters('kco_wc_checkout_url', $checkout_url);
 	}
 
 	/**

--- a/includes/class-klarna-checkout-for-woocommerce-merchant-urls.php
+++ b/includes/class-klarna-checkout-for-woocommerce-merchant-urls.php
@@ -68,7 +68,8 @@ class Klarna_Checkout_For_WooCommerce_Merchant_URLs {
 				'kco_wc_order_id' => '{checkout.order.id}',
 			), wc_get_checkout_url()
 		);
-		return $confirmation_url;
+
+		return apply_filters('kco_wc_confirmation_url',$confirmation_url);
 	}
 
 	/**
@@ -88,7 +89,7 @@ class Klarna_Checkout_For_WooCommerce_Merchant_URLs {
 			)
 		);
 
-		return $push_url;
+		return apply_filters('kco_wc_push_url', $push_url);
 	}
 
 	/**
@@ -107,8 +108,10 @@ class Klarna_Checkout_For_WooCommerce_Merchant_URLs {
 				$session_id
 			)
 		);
+		
+		$validation_url = str_replace( 'http:', 'https:', $validation_url );
 
-		return str_replace( 'http:', 'https:', $validation_url );
+		return apply_filters('kco_wc_validation_url', $validation_url);
 	}
 
 	/**
@@ -119,8 +122,12 @@ class Klarna_Checkout_For_WooCommerce_Merchant_URLs {
 	 * @return string
 	 */
 	private function get_shipping_option_update_url() {
+
 		$shipping_option_update_url = home_url('/wc-api/KCO_WC_Shipping_Option_Update/');
-		return str_replace( 'http:', 'https:', $shipping_option_update_url );
+		$shipping_option_update_url = str_replace( 'http:', 'https:', $shipping_option_update_url );
+		
+		return apply_filters('kco_wc_shipping_option_update_url', $shipping_option_update_url);
+
 	}
 
 	/**
@@ -131,8 +138,13 @@ class Klarna_Checkout_For_WooCommerce_Merchant_URLs {
 	 * @return string
 	 */
 	private function get_address_update_url() {
+
 		$address_update_url = home_url('/wc-api/KCO_WC_Address_Update/?kco_wc_order_id={checkout.order.id}');
-		return str_replace( 'http:', 'https:', $address_update_url );
+		
+		$address_update_url = str_replace( 'http:', 'https:', $address_update_url );
+		
+		return apply_filters('kco_wc_address_update_url', $address_update_url);
+
 	}
 
 	/**
@@ -144,7 +156,7 @@ class Klarna_Checkout_For_WooCommerce_Merchant_URLs {
 	 */
 	private function get_notification_url() {
 		$notification_url = home_url('/wc-api/KCO_WC_Notification/?kco_wc_order_id={checkout.order.id}');
-		return $notification_url;
+		return apply_filters('kco_wc_notification_url', $notification_url);
 	}
 
 	/**
@@ -155,8 +167,11 @@ class Klarna_Checkout_For_WooCommerce_Merchant_URLs {
 	 * @return string
 	 */
 	private function get_country_change_url() {
+
 		$country_change_url = home_url('/wp-json/kcowc/v1/address/{checkout.order.id}');
-		return str_replace( 'http:', 'https:', $country_change_url );
+		$country_change_url = str_replace( 'http:', 'https:', $country_change_url );
+		
+		return apply_filters('kco_wc_country_change_url', $country_change_url);
 	}
 
 	/**


### PR DESCRIPTION
Instead of using get_home_url() . '/our-url/' use the home_url('/our-url/') to prevent dubble dashes.

I first saw this when we used WPML with a base catalog on the default language. Our merchant urls becomes like this:
https://our-site.com/sv//wc-api/KCO_WC_Push/?kco-action=push&kco_wc_order_id={checkout.order.id}&kco_session_id=1

I also added some standard wp-filters.

