### PR TITLE
Fix for incorrect order_tax_amount when making bulk renewal requests

### DIFF
--- a/includes/class-klarna-checkout-for-woocommerce-api.php
+++ b/includes/class-klarna-checkout-for-woocommerce-api.php
@@ -908,10 +908,12 @@ class Klarna_Checkout_For_WooCommerce_API {
 			'order_amount'        => KCO_WC()->order_lines_from_order->get_order_amount( $order_id ),
 			'order_lines'         => $order_lines,
 			'purchase_currency'   => $order->get_currency(),
-			'order_tax_amount'    => KCO_WC()->order_lines_from_order->get_total_tax( $order_id ),
+			'order_tax_amount'    => KCO_WC()->order_lines_from_order->get_total_tax(),
 			'merchant_reference1' => $order->get_order_number(),
 			'merchant_reference2' => $order->get_id(),
 		);
+		KCO_WC()->order_lines_from_order->reset_total_tax();
+
 		return json_encode( $body );
 	}
 }

--- a/includes/class-klarna-checkout-for-woocommerce-order-lines-from-order.php
+++ b/includes/class-klarna-checkout-for-woocommerce-order-lines-from-order.php
@@ -66,6 +66,15 @@ class Klarna_Checkout_For_WooCommerce_Order_Lines_From_Order {
 	}
 
 	/**
+	 * Reset total tax variable.
+	 *
+	 * @return void
+	 */
+	public function reset_total_tax() {
+		$this->total_tax = 0;
+	}
+
+	/**
 	 * Get order line items.
 	 *
 	 * @param object $order_item Order item.


### PR DESCRIPTION
* Order tax amount is now getting the correct value when a bulk subscription renewal is triggered.