### PR TITLE
Clear shipping information on Klarna when the order has no shipping

### DIFF
--- a/classes/requests/checkout/post/class-kco-request-update.php
+++ b/classes/requests/checkout/post/class-kco-request-update.php
@@ -92,7 +92,10 @@ class KCO_Request_Update extends KCO_Request {
 
 		if ( ( array_key_exists( 'shipping_methods_in_iframe', $this->settings ) && 'yes' === $this->settings['shipping_methods_in_iframe'] ) && WC()->cart->needs_shipping() ) {
 			$request_body['shipping_options'] = KCO_Request_Shipping_Options::get_shipping_options( $this->separate_sales_tax );
-		}
+		} elseif (!WC()->cart->needs_shipping()) {
+			// if the order had a shipping option before but is removed now, same needs to be sent to klarna else it will retain the old shipping option
+			$request_body['shipping_options'] = [];
+        }
 
 		return $request_body;
 	}


### PR DESCRIPTION
We have come across a bug in Klarna Checkout for WooCommerce. This has to do with the combination of virtual & non-virtual products in cart.
Here are the step that allow us to replicate this issue:

1. Add virtual product(No Shipping) to cart
2. Open checkout page(optional). Works normally without issue on a fresh cart.
3. Add 1 physical product on cart
4. Open the checkout page
5. Remove physical product from cart
6. Open Checkout page

When we do step 3/4, WooCommerce updates the order at Klarna and adds a shipping option. However, when we do step 5, the shipping information for the order is not removed from Klarna. Since the KCO widget reads order from Klarna and find it out of sync with the local WooCommerce cart(no shipping), it goes into some sort of infinite loop.

Klarna Doc about update API: https://developers.klarna.com/api/#checkout-api-update-an-order
![Screenshot 2021-07-01 at 14 02 27](https://user-images.githubusercontent.com/382971/124121339-11d2f980-da75-11eb-94cb-0fae44858d38.png)

