### PR TITLE
Print the "no shipping available" message as HTML

### DIFF
--- a/assets/js/klarna-checkout-for-woocommerce.js
+++ b/assets/js/klarna-checkout-for-woocommerce.js
@@ -215,7 +215,7 @@ jQuery( function( $ ) {
 					
 				} else {
 					// No shipping method is available.
-					$('.woocommerce-shipping-totals td').text(kco_params.no_shipping_message);
+					$('.woocommerce-shipping-totals td').html(kco_params.no_shipping_message);
 				}
 			}
 		},


### PR DESCRIPTION
Sometimes the "no shipping available" message is enclosed in HTML tags (e.g., for adding the `woocommerce-error` class), and sometimes it is plain text.