### PR TITLE
Reload checkout page if cart doesn't need payment during update request

### DIFF
--- a/classes/class-kco-checkout.php
+++ b/classes/class-kco-checkout.php
@@ -95,5 +95,12 @@ class KCO_Checkout {
 			// If it is, update order.
 			$klarna_order = KCO_WC()->api->update_klarna_order( $klarna_order_id );
 		}
+
+		// If cart doesn't need payment anymore - reload the checkout page.
+		if ( apply_filters( 'kco_check_if_needs_payment', true ) ) {
+			if ( ! WC()->cart->needs_payment() && 'checkout_incomplete' === $klarna_order['status'] ) {
+				WC()->session->reload_checkout = true;
+			}
+		}
 	}
 } new KCO_Checkout();


### PR DESCRIPTION
Currently the plugin has a bug when a coupon that gives 100% discount (and free shipping) is used in checkout page. When the coupon is added and cart total results in 0, KCO is still displayed. This is not the intended behavior.

This commit adds a check in `woocommerce_after_calculate_totals`. If the cart doesn't need payment, we now set the session `WC()->session->reload_checkout` to true. WooCommerce will then automatically reload the checkout page and the KCO payment method template will no longer be used (and KCO will not be an available payment method).