### PR TITLE
Develop epm p4o

### DIFF
--- a/classes/class-kco-gateway.php
+++ b/classes/class-kco-gateway.php
@@ -82,7 +82,7 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 			add_action( 'woocommerce_receipt_kco', array( $this, 'receipt_page' ) );
 
 			add_filter( 'woocommerce_order_needs_payment', array( $this, 'maybe_change_needs_payment' ), 999, 3 );
-			add_filter( 'kco_wc_api_request_args', array( $this, 'maybe_remove_kco_epm' ), 9999, 2 );
+			add_filter( 'kco_wc_api_request_args', array( $this, 'maybe_remove_kco_epm' ), 9999 );
 		}
 
 
@@ -645,15 +645,14 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 		}
 
 		/**
-		 * Remove any external payment method.
+		 * Remove any external payment method from pay for order.
 		 *
 		 * @param array $request_args The request args.
-		 * @param int   $order_id The WooCommerce order id.
 		 *
-		 * @return mixed
+		 * @return array
 		 */
-		public function maybe_remove_kco_epm( $request_args, $order_id ) {
-			if ( isset( $request_args['external_payment_methods'] ) && ! empty( $order_id ) ) {
+		public function maybe_remove_kco_epm( $request_args ) {
+			if ( isset( $request_args['external_payment_methods'] ) && is_wc_endpoint_url( 'order-pay' ) ) {
 				unset( $request_args['external_payment_methods'] );
 			}
 

--- a/classes/requests/checkout/post/class-kco-request-create.php
+++ b/classes/requests/checkout/post/class-kco-request-create.php
@@ -117,7 +117,7 @@ class KCO_Request_Create extends KCO_Request {
 				);
 			}
 
-			$request_body['shipping_address'] = wp_parse_args( $request_body['billing_address'], $request_body['shipping_address'] );
+			$request_body['shipping_address'] = wp_parse_args( $request_body['billing_address'], $request_body['shipping_address'] ?? array() );
 		}
 
 		if ( ( array_key_exists( 'shipping_methods_in_iframe', $this->settings ) && 'yes' === $this->settings['shipping_methods_in_iframe'] ) && WC()->cart->needs_shipping() ) {

--- a/classes/requests/checkout/post/class-kco-request-update.php
+++ b/classes/requests/checkout/post/class-kco-request-update.php
@@ -89,7 +89,7 @@ class KCO_Request_Update extends KCO_Request {
 				'region'          => WC()->checkout()->get_value( 'billing_state' ),
 			);
 
-			$request_body['shipping_address'] = wp_parse_args( $request_body['billing_address'], $request_body['shipping_address'] );
+			$request_body['shipping_address'] = wp_parse_args( $request_body['billing_address'], $request_body['shipping_address'] ?? array() );
 		}
 
 		if ( ( array_key_exists( 'shipping_methods_in_iframe', $this->settings ) && 'yes' === $this->settings['shipping_methods_in_iframe'] ) && WC()->cart->needs_shipping() ) {


### PR DESCRIPTION
External payment methods ("EPM") are not available in pay for order.

This fixes the issue with EPM not being available on the embedded checkout page since the `order_id` is also not available there until after the customer has placed an order.