### PR TITLE
Conditionally enqueue JavaScript

### DIFF
--- a/classes/class-kco-gateway.php
+++ b/classes/class-kco-gateway.php
@@ -222,6 +222,11 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 				return;
 			}
 
+			/* Only enqueue for pages where the checkout form should appear. */
+			if ( ! ( is_checkout() || is_wc_endpoint_url( 'order-pay' ) ) ) {
+				return;
+			}
+
 			$pay_for_order = false;
 			if ( is_wc_endpoint_url( 'order-pay' ) ) {
 				$pay_for_order = true;


### PR DESCRIPTION
KCO does not need to run outside the checkout and order-pay pages. This should fix the issue with Twenty Twenty One/Two themes where the "add to cart" button would disappear each time it was clicked.