### PR TITLE
Checkout reload indefinitely

### DIFF
--- a/classes/class-kco-gateway.php
+++ b/classes/class-kco-gateway.php
@@ -198,6 +198,19 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 						return false;
 					}
 				}
+
+				/**
+				 * Prevent the checkout from loading to prevent an issue where we reload to switch to a different payment gateway,
+				 * but Klarna Checkout is the only one available, thus causing an indefinite reload since WC is redirecting back to Klarna Checkout.
+				 *
+				 * This happens when the the cart contain a subscription with a free trial, and since an order needs to be created to register
+				 * a new subscription, the check WC()->cart->needs_payment will be TRUE.
+				 */
+				if ( apply_filters( 'kco_check_if_needs_payment', true ) ) {
+					if ( empty( floatval( WC()->cart->total ) ) ) {
+						return false;
+					}
+				}
 			}
 
 			return true;

--- a/classes/class-kco-gateway.php
+++ b/classes/class-kco-gateway.php
@@ -184,16 +184,19 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 				return false;
 			}
 
-			// If we can't retrieve a set of credentials, disable KCO.
-			if ( is_checkout() && ! KCO_WC()->credentials->get_credentials_from_session() ) {
-				return false;
-			}
+			if ( is_checkout() ) {
 
-			// If we have a subscription product in cart and the customer isn't from SE, NO, FI, DE or AT, disable KCO.
-			if ( is_checkout() && class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) {
-				$available_recurring_countries = array( 'SE', 'NO', 'FI', 'DE', 'AT' );
-				if ( ! in_array( WC()->customer->get_billing_country(), $available_recurring_countries, true ) ) {
+				// If we can't retrieve a set of credentials, disable KCO.
+				if ( ! KCO_WC()->credentials->get_credentials_from_session() ) {
 					return false;
+				}
+
+				// If we have a subscription product in cart and the customer isn't from SE, NO, FI, DE or AT, disable KCO.
+				if ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) {
+					$available_recurring_countries = array( 'SE', 'NO', 'FI', 'DE', 'AT' );
+					if ( ! in_array( WC()->customer->get_billing_country(), $available_recurring_countries, true ) ) {
+						return false;
+					}
 				}
 			}
 


### PR DESCRIPTION
Prevent the checkout early from loading to prevent an issue where we reload to switch to a different payment gateway, but Klarna Checkout is the only one available, thus causing an indefinite reload since WC is redirecting back to Klarna Checkout. This happens when the cart contain a subscription with a free trial, and since an order needs to be created to register a new subscription, the check `WC()->cart->needs_payment` will be `TRUE`.