### PR TITLE
Prefill company user data if available

### DIFF
--- a/classes/requests/checkout/post/class-kco-request-create.php
+++ b/classes/requests/checkout/post/class-kco-request-create.php
@@ -78,16 +78,17 @@ class KCO_Request_Create extends KCO_Request {
 
 		if ( kco_wc_prefill_allowed() ) {
 			$request_body['billing_address'] = array(
-				'email'           => WC()->checkout()->get_value( 'billing_email' ),
-				'postal_code'     => WC()->checkout()->get_value( 'billing_postcode' ),
-				'country'         => WC()->checkout()->get_value( 'billing_country' ),
-				'phone'           => WC()->checkout()->get_value( 'billing_phone' ),
-				'given_name'      => WC()->checkout()->get_value( 'billing_first_name' ),
-				'family_name'     => WC()->checkout()->get_value( 'billing_last_name' ),
-				'street_address'  => WC()->checkout()->get_value( 'billing_address_1' ),
-				'street_address2' => WC()->checkout()->get_value( 'billing_address_2' ),
-				'city'            => WC()->checkout()->get_value( 'billing_city' ),
-				'region'          => WC()->checkout()->get_value( 'billing_state' ),
+				'email'             => WC()->checkout()->get_value( 'billing_email' ),
+				'postal_code'       => WC()->checkout()->get_value( 'billing_postcode' ),
+				'country'           => WC()->checkout()->get_value( 'billing_country' ),
+				'phone'             => WC()->checkout()->get_value( 'billing_phone' ),
+				'given_name'        => WC()->checkout()->get_value( 'billing_first_name' ),
+				'family_name'       => WC()->checkout()->get_value( 'billing_last_name' ),
+				'organization_name' => WC()->checkout()->get_value( 'billing_company' ),
+				'street_address'    => WC()->checkout()->get_value( 'billing_address_1' ),
+				'street_address2'   => WC()->checkout()->get_value( 'billing_address_2' ),
+				'city'              => WC()->checkout()->get_value( 'billing_city' ),
+				'region'            => WC()->checkout()->get_value( 'billing_state' ),
 			);
 
 			if ( 'yes' === $this->settings['allow_separate_shipping'] ) {
@@ -104,16 +105,17 @@ class KCO_Request_Create extends KCO_Request {
 				}
 
 				$request_body['shipping_address'] = array(
-					'postal_code'     => WC()->checkout()->get_value( 'shipping_postcode' ),
-					'country'         => WC()->checkout()->get_value( 'shipping_country' ),
-					'given_name'      => WC()->checkout()->get_value( 'shipping_first_name' ),
-					'family_name'     => WC()->checkout()->get_value( 'shipping_last_name' ),
-					'street_address'  => WC()->checkout()->get_value( 'shipping_address_1' ),
-					'street_address2' => WC()->checkout()->get_value( 'shipping_address_2' ),
-					'city'            => WC()->checkout()->get_value( 'shipping_city' ),
-					'region'          => WC()->checkout()->get_value( 'shipping_state' ),
-					'phone'           => $shipping_phone,
-					'email'           => $shipping_email,
+					'postal_code'       => WC()->checkout()->get_value( 'shipping_postcode' ),
+					'country'           => WC()->checkout()->get_value( 'shipping_country' ),
+					'given_name'        => WC()->checkout()->get_value( 'shipping_first_name' ),
+					'family_name'       => WC()->checkout()->get_value( 'shipping_last_name' ),
+					'organization_name' => WC()->checkout()->get_value( 'shipping_company' ),
+					'street_address'    => WC()->checkout()->get_value( 'shipping_address_1' ),
+					'street_address2'   => WC()->checkout()->get_value( 'shipping_address_2' ),
+					'city'              => WC()->checkout()->get_value( 'shipping_city' ),
+					'region'            => WC()->checkout()->get_value( 'shipping_state' ),
+					'phone'             => $shipping_phone,
+					'email'             => $shipping_email,
 				);
 			}
 

--- a/classes/requests/checkout/post/class-kco-request-update.php
+++ b/classes/requests/checkout/post/class-kco-request-update.php
@@ -77,16 +77,29 @@ class KCO_Request_Update extends KCO_Request {
 
 		if ( kco_wc_prefill_allowed() ) {
 			$request_body['billing_address'] = array(
-				'email'           => WC()->checkout()->get_value( 'billing_email' ),
-				'postal_code'     => WC()->checkout()->get_value( 'billing_postcode' ),
-				'country'         => WC()->checkout()->get_value( 'billing_country' ),
-				'phone'           => WC()->checkout()->get_value( 'billing_phone' ),
-				'given_name'      => WC()->checkout()->get_value( 'billing_first_name' ),
-				'family_name'     => WC()->checkout()->get_value( 'billing_last_name' ),
-				'street_address'  => WC()->checkout()->get_value( 'billing_address_1' ),
-				'street_address2' => WC()->checkout()->get_value( 'billing_address_2' ),
-				'city'            => WC()->checkout()->get_value( 'billing_city' ),
-				'region'          => WC()->checkout()->get_value( 'billing_state' ),
+				'email'             => WC()->checkout()->get_value( 'billing_email' ),
+				'postal_code'       => WC()->checkout()->get_value( 'billing_postcode' ),
+				'country'           => WC()->checkout()->get_value( 'billing_country' ),
+				'phone'             => WC()->checkout()->get_value( 'billing_phone' ),
+				'given_name'        => WC()->checkout()->get_value( 'billing_first_name' ),
+				'family_name'       => WC()->checkout()->get_value( 'billing_last_name' ),
+				'organization_name' => WC()->checkout()->get_value( 'billing_company' ),
+				'street_address'    => WC()->checkout()->get_value( 'billing_address_1' ),
+				'street_address2'   => WC()->checkout()->get_value( 'billing_address_2' ),
+				'city'              => WC()->checkout()->get_value( 'billing_city' ),
+				'region'            => WC()->checkout()->get_value( 'billing_state' ),
+			);
+
+			$request_body['shipping_address'] = array(
+				'postal_code'       => WC()->checkout()->get_value( 'shipping_postcode' ),
+				'country'           => WC()->checkout()->get_value( 'shipping_country' ),
+				'given_name'        => WC()->checkout()->get_value( 'shipping_first_name' ),
+				'family_name'       => WC()->checkout()->get_value( 'shipping_last_name' ),
+				'organization_name' => WC()->checkout()->get_value( 'shipping_company' ),
+				'street_address'    => WC()->checkout()->get_value( 'shipping_address_1' ),
+				'street_address2'   => WC()->checkout()->get_value( 'shipping_address_2' ),
+				'city'              => WC()->checkout()->get_value( 'shipping_city' ),
+				'region'            => WC()->checkout()->get_value( 'shipping_state' ),
 			);
 
 			$request_body['shipping_address'] = wp_parse_args( $request_body['billing_address'], $request_body['shipping_address'] ?? array() );


### PR DESCRIPTION
B2B is only prefilled if B2B is the default customer type. If you switch to B2B, Klarna will ignore the company information in the update request.