### PR TITLE
Fix passed by reference warning

### DIFF
--- a/classes/requests/helpers/class-kco-request-order.php
+++ b/classes/requests/helpers/class-kco-request-order.php
@@ -121,8 +121,7 @@ class KCO_Request_Order {
 	 * @return array
 	 */
 	public function get_order_line_shipping( $order ) {
-
-		$shipping_item = reset( $order->get_shipping_methods() );
+		$shipping_item = array_slice( $order->get_shipping_methods(), 0, 1 )[0];
 
 		return array(
 			'type'             => 'shipping_fee',


### PR DESCRIPTION
`reset` wants a reference, not a function expression.

We assume that `get_shipping_methods` never returns an empty array (that would crash `reset` too).