### PR TITLE
Fix total amount comparison for negative subscription fees

### DIFF
--- a/classes/requests/helpers/class-kco-request-order.php
+++ b/classes/requests/helpers/class-kco-request-order.php
@@ -282,10 +282,10 @@ class KCO_Request_Order {
 	public function get_fee_total_amount( $order, $order_fee ) {
 		if ( $this->separate_sales_tax ) {
 			$fee_total_amount      = number_format( ( $order_fee->get_total() ) * ( 1 + ( $this->get_order_line_tax_rate( $order, $order_fee ) / 10000 ) ), wc_get_price_decimals(), '.', '' ) * 100;
-			$max_order_line_amount = ( number_format( ( $order_fee->get_total() + $order_fee->get_total_tax() ) * 100, wc_get_price_decimals(), '.', '' ) * $order_fee->get_quantity() ) * 100;
+			$max_order_line_amount = ( number_format( ( $order_fee->get_total() + $order_fee->get_total_tax() ) * 100, wc_get_price_decimals(), '.', '' ) * $order_fee->get_quantity() );
 		} else {
 			$fee_total_amount      = number_format( ( $order_fee->get_total() ) * ( 1 + ( $this->get_order_line_tax_rate( $order, $order_fee ) / 10000 ) ), wc_get_price_decimals(), '.', '' ) * 100;
-			$max_order_line_amount = ( number_format( ( $order_fee->get_total() + $order_fee->get_total_tax() ) * 100, wc_get_price_decimals(), '.', '' ) * $order_fee->get_quantity() ) * 100;
+			$max_order_line_amount = ( number_format( ( $order_fee->get_total() + $order_fee->get_total_tax() ) * 100, wc_get_price_decimals(), '.', '' ) * $order_fee->get_quantity() );
 		}
 		// Check so the line_total isn't greater than product price x quantity.
 		// This can happen when having price display set to 0 decimals.


### PR DESCRIPTION
There is no need to multiply `$max_order_line_amount` by 100 as unlike `$fee_total_amount` it is not divided by 10000.