### PR TITLE
Check if log object is instance of WP_Hook

### DIFF
--- a/classes/class-kco-logger.php
+++ b/classes/class-kco-logger.php
@@ -107,7 +107,7 @@ class KCO_Logger {
 			$extra_data = '';
 			if ( ! in_array( $data['function'], array( 'get_stack', 'format_log' ), true ) ) {
 				if ( in_array( $data['function'], array( 'do_action', 'apply_filters' ), true ) ) {
-					if ( isset( $data['object'] ) ) {
+					if ( isset( $data['object'] ) && $data['object'] instanceof WP_Hook ) {
 						$priority   = $data['object']->current_priority();
 						$name       = key( $data['object']->current() );
 						$extra_data = $name . ' : ' . $priority;


### PR DESCRIPTION
These methods are only available in instances of `WP_Hook`.