### PR TITLE
Fixed issue no #517 - Typo mistake in  object (set_status function)

### DIFF
--- a/includes/kco-functions.php
+++ b/includes/kco-functions.php
@@ -617,9 +617,9 @@ function kco_confirm_klarna_order( $order_id = null, $klarna_order_id = null ) {
 				KCO_Logger::log( $klarna_order_id . ': Fraud status pending for order ' . $order->get_order_number() . '. Order set to on-hold.' );
 			} elseif ( 'REJECTED' === $klarna_order['fraud_status'] ) {
 				// Cancel the order.
-				$order->set_status( 'canceled', __( 'Klarna Checkout order was rejected', 'klarna-checkout-for-woocommerce' ) );
+				$order->set_status( 'cancelled', __( 'Klarna Checkout order was rejected', 'klarna-checkout-for-woocommerce' ) );
 				$order->save();
-				KCO_Logger::log( $klarna_order_id . ': Fraud status rejected for order ' . $order->get_order_number() . '. Order canceled.' );
+				KCO_Logger::log( $klarna_order_id . ': Fraud status rejected for order ' . $order->get_order_number() . '. Order cancelled.' );
 			}
 		} else {
 			$order->set_status( 'on-hold', __( 'Waiting for verification from Klarnas push notification', 'klarna-checkout-for-woocommerce' ) );


### PR DESCRIPTION
Wrong $order->set_status( 'canceled', ' ', ' ' ); in klarna-checkout-for-woocommerce/includes/kco-functions.php

Fixed that status according issue no #517 