### PR TITLE
Fix smart coupons when "apply before tax" is disabled

### DIFF
--- a/classes/class-kco-checkout.php
+++ b/classes/class-kco-checkout.php
@@ -19,7 +19,7 @@ class KCO_Checkout {
 	public function __construct() {
 		add_filter( 'woocommerce_checkout_fields', array( $this, 'add_shipping_data_input' ) );
 		add_action( 'woocommerce_before_calculate_totals', array( $this, 'update_shipping_method' ), 9999 );
-		add_action( 'woocommerce_after_calculate_totals', array( $this, 'update_klarna_order' ), 9999 );
+		add_action( 'woocommerce_after_calculate_totals', array( $this, 'update_klarna_order' ), 99999 );
 
 		// Handle potential shipping selection errors.
 		add_filter( 'woocommerce_shipping_chosen_method', array( $this, 'maybe_register_shipping_error' ), 9999, 3 );

--- a/classes/requests/helpers/class-kco-request-cart.php
+++ b/classes/requests/helpers/class-kco-request-cart.php
@@ -122,7 +122,7 @@ class KCO_Request_Cart {
 	 * @return array
 	 */
 	public function adjust_order_lines() {
-		$amount_to_adjust = $this->get_order_amount() - $this->get_order_lines_total_amount( $this->order_lines );
+		$amount_to_adjust = $this->get_order_amount() - $this->get_order_lines_total_amount();
 
 		// If the amount to adjust is zero, return.
 		if ( 0 === intval( round( $amount_to_adjust * 100 ) ) ) {

--- a/classes/requests/helpers/class-kco-request-cart.php
+++ b/classes/requests/helpers/class-kco-request-cart.php
@@ -292,13 +292,13 @@ class KCO_Request_Cart {
 						$coupon_amount    = 0;
 						$coupon_reference = __( 'Gift card', 'klarna-checkout-for-woocommerce' ) . ' (amount: ' . WC()->cart->get_coupon_discount_amount( $coupon_key, 'no' === get_option( 'woocommerce_prices_include_tax' ) ) . ')';
 					} else {
-						$coupon_amount    = - WC()->cart->get_coupon_discount_amount( $coupon_key ) * 100;
-						$coupon_reference = __( 'Gift card', 'klarna-checkout-for-woocommerce' );
+						$coupon_amount    = - $coupon->get_amount() * 100;
+						$coupon_reference = __( 'Gift card', 'klarna-checkout-for-woocommerce' ) . ' (amount: ' . $coupon->get_amount() . ')';
 					}
 					$coupon_tax_amount = - WC()->cart->get_coupon_discount_tax_amount( $coupon_key ) * 100;
 				} elseif ( 'US' === $this->shop_country ) {
-						$coupon_amount     = 0;
-						$coupon_tax_amount = 0;
+					$coupon_amount     = 0;
+					$coupon_tax_amount = 0;
 					if ( $coupon->is_type( 'fixed_cart' ) || $coupon->is_type( 'percent' ) ) {
 						$coupon_type = 'Cart discount';
 					} elseif ( $coupon->is_type( 'fixed_product' ) || $coupon->is_type( 'percent_product' ) ) {
@@ -306,7 +306,7 @@ class KCO_Request_Cart {
 					} else {
 						$coupon_type = 'Discount';
 					}
-						$coupon_reference = $coupon_type . ' (amount: ' . WC()->cart->get_coupon_discount_amount( $coupon_key ) . ', tax amount: ' . WC()->cart->get_coupon_discount_tax_amount( $coupon_key ) . ')';
+					$coupon_reference = $coupon_type . ' (amount: ' . WC()->cart->get_coupon_discount_amount( $coupon_key ) . ', tax amount: ' . WC()->cart->get_coupon_discount_tax_amount( $coupon_key ) . ')';
 
 				}
 				// Add separate discount line item, but only if it's a smart coupon or country is US.

--- a/classes/requests/helpers/class-kco-request-cart.php
+++ b/classes/requests/helpers/class-kco-request-cart.php
@@ -290,7 +290,7 @@ class KCO_Request_Cart {
 					// the sum is discounted from order lines so we send it as 0 for reference.
 					if ( wc_tax_enabled() && 'yes' === $apply_before_tax ) {
 						$coupon_amount    = 0;
-						$coupon_reference = __( 'Gift card', 'klarna-checkout-for-woocommerce' ) . ' (amount: ' . WC()->cart->get_coupon_discount_amount( $coupon_key ) . ')';
+						$coupon_reference = __( 'Gift card', 'klarna-checkout-for-woocommerce' ) . ' (amount: ' . WC()->cart->get_coupon_discount_amount( $coupon_key, 'no' === get_option( 'woocommerce_prices_include_tax' ) ) . ')';
 					} else {
 						$coupon_amount    = - WC()->cart->get_coupon_discount_amount( $coupon_key ) * 100;
 						$coupon_reference = __( 'Gift card', 'klarna-checkout-for-woocommerce' );


### PR DESCRIPTION
Previously, we used the Cart object to retrieve the coupon, which would yield 0 in all cases when "Apply before tax" is disabled in the smart coupons settings.