### PR TITLE
Add HPOS compatibility

### DIFF
--- a/classes/class-kco-api-callbacks.php
+++ b/classes/class-kco-api-callbacks.php
@@ -68,26 +68,27 @@ class KCO_API_Callbacks {
 		// Used by Klarna_Checkout_Subscription::handle_push_cb_for_payment_method_change().
 		do_action( 'wc_klarna_push_cb', $klarna_order_id );
 
-		$query_args = array(
-			'fields'      => 'ids',
-			'post_type'   => wc_get_order_types(),
-			'post_status' => array_keys( wc_get_order_statuses() ),
-			'meta_key'    => '_wc_klarna_order_id', // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
-			'meta_value'  => $klarna_order_id, // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
+		$orders = wc_get_orders(
+			array(
+				'meta_query' => array(
+					array(
+						'key'     => '_wc_klarna_order_id',
+						'value'   => $klarna_order_id,
+						'compare' => '=',
+					),
+				),
+			)
 		);
 
-		$orders = get_posts( $query_args );
-
-		// If zero matching orders were found, create backup order.
-		if ( empty( $orders ) ) {
+		$order = reset( $orders );
+		if ( empty( $order ) ) {
 			// Backup order creation.
 			KCO_WC()->logger->log( 'ERROR Push callback but no existing WC order found for Klarna order ID ' . stripslashes_deep( wp_json_encode( $klarna_order_id ) ) );
 			return;
+
 		}
 
-		$order_id = $orders[0];
-		$order    = wc_get_order( $order_id );
-
+		$order_id = $order->get_id();
 		if ( $order ) {
 			// Get the Klarna order data.
 			$klarna_order = apply_filters(
@@ -139,28 +140,28 @@ class KCO_API_Callbacks {
 		 * 4. If WooCommerce order does exist, fire the hook.
 		 */
 
-		$order_id        = '';
 		$klarna_order_id = filter_input( INPUT_GET, 'kco_wc_order_id', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( ! empty( $klarna_order_id ) ) {
-			$klarna_order_id = $klarna_order_id;
-			$query_args      = array(
-				'fields'      => 'ids',
-				'post_type'   => wc_get_order_types(),
-				'post_status' => array_keys( wc_get_order_statuses() ),
-				'meta_key'    => '_wc_klarna_order_id', // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
-				'meta_value'  => $klarna_order_id, // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
+			$orders = wc_get_orders(
+				array(
+					'meta_query' => array(
+						array(
+							'key'     => '_wc_klarna_order_id',
+							'value'   => $klarna_order_id,
+							'compare' => '=',
+						),
+					),
+				)
 			);
 
-			$orders = get_posts( $query_args );
-
-			// If zero matching orders were found, return.
-			if ( ! empty( $orders ) ) {
-				$order_id = $orders[0];
+			$order = reset( $orders );
+			if ( ! empty( $order ) ) {
+				$order_id = $order->get_id();
 			}
 		}
 
-		if ( '' !== $order_id ) {
+		if ( isset( $order_id ) ) {
 			do_action( 'wc_klarna_notification_listener' );
 		} else {
 			$post_body = file_get_contents( 'php://input' );

--- a/classes/class-kco-confirmation.php
+++ b/classes/class-kco-confirmation.php
@@ -94,28 +94,25 @@ class KCO_Confirmation {
 	 */
 	public function run_kepm( $epm, $order_id, $klarna_order_id ) {
 		$order = wc_get_order( $order_id );
-		// Check if we have a KCO order id.
-		if ( ! empty( $klarna_order_id ) && ! $order ) {
-			// Do a database lookup for the WooCommerce order.
-			$query_args = array(
-				'fields'      => 'ids',
-				'post_type'   => wc_get_order_types(),
-				'post_status' => array_keys( wc_get_order_statuses() ),
-				'meta_key'    => '_wc_klarna_order_id', // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
-				'meta_value'  => $klarna_order_id, // phpcs:ignore WordPress.DB.SlowDBQuery -- Slow DB Query is ok here, we need to limit to our meta key.
-				'date_query'  => array(
-					array(
-						'after' => '2 day ago',
+
+		// Try to retrieve the WC_Order using the Klarna order id.
+		if ( empty( $order ) && ! empty( $klarna_order_id ) ) {
+			$orders = wc_get_orders(
+				array(
+					'meta_query' => array(
+						array(
+							'key'     => '_wc_klarna_order_id',
+							'value'   => $klarna_order_id,
+							'compare' => '=',
+						),
 					),
-				),
+					'date_after' => '2 days ago',
+				)
 			);
-			$orders     = get_posts( $query_args );
-			// Set the order from the first order id returned.
-			if ( ! empty( $orders ) ) {
-				$order_id = $orders[0];
-				$order    = wc_get_order( $order_id );
-			}
+
+			$order = reset( $orders );
 		}
+
 		// Check if we have a order.
 		if ( ! $order ) {
 			wc_print_notice( __( 'Failed getting the order for the external payment.', 'klarna-checkout-for-woocommerce' ), 'error' );

--- a/classes/class-kco-gateway.php
+++ b/classes/class-kco-gateway.php
@@ -398,11 +398,10 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 		public function process_embedded_payment_handler( $order_id ) {
 			// Get the Klarna order ID.
 			$order = wc_get_order( $order_id );
-			if ( is_object( $order ) && ! empty( get_post_meta( $order->get_id(), '_wc_klarna_order_id', true ) ) ) {
-				$klarna_order_id = get_post_meta( $order->get_id(), '_wc_klarna_order_id', true );
-			} else {
-				$klarna_order_id = WC()->session->get( 'kco_wc_order_id' );
+			if ( ! empty( $order ) ) {
+				$klarna_order_id = $order->get_meta( '_wc_klarna_order_id', true );
 			}
+			$klarna_order_id = ! empty( $klarna_order_id ) ? $klarna_order_id : WC()->session->get( 'kco_wc_order_id' );
 
 			$klarna_order = KCO_WC()->api->get_klarna_order( $klarna_order_id );
 
@@ -473,8 +472,9 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 
 			$hpp_redirect = $hpp['redirect_url'];
 			// Save Klarna HPP url & Session ID.
-			update_post_meta( $order_id, '_wc_klarna_hpp_url', sanitize_text_field( $hpp_redirect ) );
-			update_post_meta( $order_id, '_wc_klarna_hpp_session_id', sanitize_key( $hpp['session_id'] ) );
+			$order->update_meta_data( '_wc_klarna_hpp_url', sanitize_text_field( $hpp_redirect ) );
+			$order->update_meta_data( '_wc_klarna_hpp_session_id', sanitize_key( $hpp['session_id'] ) );
+			$order->save();
 
 			KCO_Logger::log( sprintf( 'Processing order %s|%s (Klarna ID: %s) OK. Redirecting to hosted payment page.', $order_id, $order->get_order_number(), $klarna_order['order_id'] ) );
 
@@ -497,26 +497,33 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 		 * @return void.
 		 */
 		public function save_metadata_to_order( $order_id, $klarna_order, $checkout_flow = 'embedded' ) {
+			$order = wc_get_order( $order_id );
 
 			// Set Klarna checkout flow.
-			update_post_meta( $order_id, '_wc_klarna_checkout_flow', sanitize_text_field( $checkout_flow ) );
+			$order->update_meta_data( '_wc_klarna_checkout_flow', sanitize_text_field( $checkout_flow ) );
 
 			// Set Klarna order ID.
-			update_post_meta( $order_id, '_wc_klarna_order_id', sanitize_key( $klarna_order['order_id'] ) );
+			$order->update_meta_data( '_wc_klarna_order_id', sanitize_key( $klarna_order['order_id'] ) );
 
 			if ( isset( $klarna_order['recurring_token'] ) ) {
-				update_post_meta( $order_id, '_kco_recurring_token', sanitize_key( $klarna_order['recurring_token'] ) );
+				$order->update_meta_data( '_kco_recurring_token', sanitize_key( $klarna_order['recurring_token'] ) );
 			}
 
 			$environment = $this->testmode ? 'test' : 'live';
-			update_post_meta( $order_id, '_wc_klarna_environment', $environment );
+			$order->update_meta_data( '_wc_klarna_environment', $environment );
 
 			$klarna_country = wc_get_base_location()['country'];
-			update_post_meta( $order_id, '_wc_klarna_country', $klarna_country );
+			$order->update_meta_data( '_wc_klarna_country', $klarna_country );
 
-			// Set shipping phone and email.
-			update_post_meta( $order_id, '_shipping_phone', sanitize_text_field( $klarna_order['shipping_address']['phone'] ) );
-			update_post_meta( $order_id, '_shipping_email', sanitize_text_field( $klarna_order['shipping_address']['email'] ) );
+			// NOTE: Since we declare support for WC v4+, and WC_Order::set_shipping_phone was only added in 5.6.0, we need to use update_meta_data instead. There is no default shipping email field in WC.
+			if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '5.6.0', '>=' ) ) {
+				$order->set_shipping_phone( sanitize_text_field( $klarna_order['shipping_address']['phone'] ) );
+			} else {
+				$order->update_meta_data( '_shipping_phone', sanitize_text_field( $klarna_order['shipping_address']['phone'] ) );
+			}
+
+			$order->update_meta_data( '_shipping_email', sanitize_text_field( $klarna_order['shipping_address']['email'] ) );
+			$order->save();
 		}
 
 		/**
@@ -624,12 +631,13 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 		 */
 		public function add_billing_org_nr( $order ) {
 			if ( $this->id === $order->get_payment_method() ) {
-				$order_id = $order->get_id();
-				$org_nr   = get_post_meta( $order_id, '_billing_org_nr', true );
+				$org_nr = $order->get_meta( '_billing_org_nr', true );
 				if ( $org_nr ) {
 					?>
 					<p>
-						<strong><?php esc_html_e( 'Organisation number:', 'klarna-checkout-for-woocommerce' ); ?></strong>
+						<strong>
+							<?php esc_html_e( 'Organisation number:', 'klarna-checkout-for-woocommerce' ); ?>
+						</strong>
 						<?php echo esc_html( $org_nr ); ?>
 					</p>
 					<?php
@@ -645,12 +653,13 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 		 */
 		public function add_billing_reference( $order ) {
 			if ( $this->id === $order->get_payment_method() ) {
-				$order_id  = $order->get_id();
-				$reference = get_post_meta( $order_id, '_billing_reference', true );
+				$reference = $order->get_meta( '_billing_reference', true );
 				if ( $reference ) {
 					?>
 					<p>
-						<strong><?php esc_html_e( 'Reference:', 'klarna-checkout-for-woocommerce' ); ?></strong>
+						<strong>
+							<?php esc_html_e( 'Reference:', 'klarna-checkout-for-woocommerce' ); ?>
+						</strong>
 						<?php echo esc_html( $reference ); ?>
 					</p>
 					<?php
@@ -666,12 +675,13 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 		 */
 		public function add_shipping_reference( $order ) {
 			if ( $this->id === $order->get_payment_method() ) {
-				$order_id  = $order->get_id();
-				$reference = get_post_meta( $order_id, '_shipping_reference', true );
+				$reference = $order->get_meta( '_shipping_reference', true );
 				if ( $reference ) {
 					?>
 					<p>
-						<strong><?php esc_html_e( 'Reference:', 'klarna-checkout-for-woocommerce' ); ?></strong>
+						<strong>
+							<?php esc_html_e( 'Reference:', 'klarna-checkout-for-woocommerce' ); ?>
+						</strong>
 						<?php echo esc_html( $reference ); ?>
 					</p>
 					<?php
@@ -724,7 +734,8 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 		 * @return bool
 		 */
 		public function upsell_available( $order_id ) {
-			$klarna_order_id = get_post_meta( $order_id, '_wc_klarna_order_id', true );
+			$order           = wc_get_order( $order_id );
+			$klarna_order_id = $order->get_meta( '_wc_klarna_order_id', true );
 
 			if ( empty( $klarna_order_id ) ) {
 				return false;

--- a/classes/class-kco-subscription.php
+++ b/classes/class-kco-subscription.php
@@ -246,26 +246,34 @@ class KCO_Subscription {
 				$wc_order->add_order_note( $note );
 
 				foreach ( $subscriptions as $subscription ) {
-					update_post_meta( $subscription->get_id(), '_kco_recurring_token', $recurring_token );
+					$subscription_order = wc_get_order( $subscription->get_id() );
+					$subscription_order->update_meta_data( '_kco_recurring_token', $recurring_token );
 
 					// Do not overwrite any existing phone number in case the customer has changed payment method (and thus shipping details).
 					if ( empty( $subscription->get_shipping_phone() ) ) {
-						$subscription->set_shipping_phone( $klarna_order['shipping_address']['phone'] );
-						$subscription->save();
+
+						// NOTE: Since we declare support for WC v4+, and WC_Order::set_shipping_phone was only added in 5.6.0, we need to use update_meta_data instead. There is no default shipping email field in WC.
+						if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '5.6.0', '>=' ) ) {
+							$subscription->set_shipping_phone( $klarna_order['shipping_address']['phone'] );
+						} else {
+							$subscription->update_meta_data( '_shipping_phone', $klarna_order['shipping_address']['phone'] );
+						}
 					}
+					$subscription->save();
 				}
 
 				// Also update the renewal order with the new recurring token.
-				update_post_meta( $order_id, '_kco_recurring_token', sanitize_key( $recurring_token ) );
+				$wc_order->update_meta_data( '_kco_recurring_token', sanitize_key( $recurring_token ) );
 
 			} else {
 				$wc_order->add_order_note( __( 'Recurring token was missing from the Klarna order during the checkout process. Please contact Klarna for help.', 'klarna-checkout-for-woocommerce' ) );
 				$wc_order->set_status( 'on-hold' );
-				$wc_order->save();
 				foreach ( $subscriptions as $subscription ) {
 					$subscription->set_status( 'on-hold' );
 				}
 			}
+
+			$wc_order->save();
 		}
 	}
 
@@ -278,8 +286,10 @@ class KCO_Subscription {
 	 */
 	public function set_recurring_token_for_subscription( $subscription_id = null, $klarna_order = null ) {
 		if ( isset( $klarna_order['recurring_token'] ) ) {
-			$recurring_token = $klarna_order['recurring_token'];
-			update_post_meta( $subscription_id, '_kco_recurring_token', $recurring_token );
+			$recurring_token    = $klarna_order['recurring_token'];
+			$subscription_order = wc_get_order( $subscription_id );
+			$subscription_order->update_meta_data( '_kco_recurring_token', $recurring_token );
+			$subscription_order->save();
 		}
 	}
 
@@ -293,30 +303,33 @@ class KCO_Subscription {
 		$order_id = $renewal_order->get_id();
 
 		$subscriptions   = wcs_get_subscriptions_for_renewal_order( $renewal_order->get_id() );
-		$recurring_token = get_post_meta( $order_id, '_kco_recurring_token', true );
+		$recurring_token = $renewal_order->get_meta( '_kco_recurring_token', true );
 
 		if ( empty( $recurring_token ) ) {
 			// Try getting it from parent order.
-			$recurring_token = get_post_meta( WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_kco_recurring_token', true );
-			update_post_meta( $order_id, '_kco_recurring_token', $recurring_token );
+			$recurring_token = wc_get_order( WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ) )->get_meta( '_kco_recurring_token', true );
+			$renewal_order->update_meta_data( '_kco_recurring_token', $recurring_token );
 		}
 
 		if ( empty( $recurring_token ) ) {
 			// Try getting it from _klarna_recurring_token (the old Klarna plugin).
-			$recurring_token = get_post_meta( $order_id, '_klarna_recurring_token', true );
+			$recurring_token = $renewal_order->get_meta( '_klarna_recurring_token', true );
 
 			if ( empty( $recurring_token ) ) {
-				$recurring_token = get_post_meta( WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ), '_klarna_recurring_token', true );
-				update_post_meta( $order_id, '_klarna_recurring_token', $recurring_token );
+				$recurring_token = wc_get_order( WC_Subscriptions_Renewal_Order::get_parent_order_id( $order_id ) )->get_meta( '_klarna_recurring_token', true );
+				$renewal_order->update_meta_data( '_klarna_recurring_token', $recurring_token );
 			}
 
 			if ( ! empty( $recurring_token ) ) {
-				update_post_meta( $order_id, '_kco_recurring_token', $recurring_token );
+				$renewal_order->update_meta_data( '_kco_recurring_token', $recurring_token );
 				foreach ( $subscriptions as $subscription ) {
-					update_post_meta( $subscription->get_id(), '_kco_recurring_token', $recurring_token );
+					$subscription_order = wc_get_order( $subscription->get_id() );
+					$subscription_order->update_meta_data( '_kco_recurring_token', $recurring_token );
+					$subscription_order->save();
 				}
 			}
 		}
+		$renewal_order->save();
 
 		$create_order_response = KCO_WC()->api->create_recurring_order( $order_id, $recurring_token );
 		if ( ! is_wp_error( $create_order_response ) ) {
@@ -343,7 +356,7 @@ class KCO_Subscription {
 	 * @return void
 	 */
 	public function show_recurring_token( $order ) {
-		if ( 'shop_subscription' === $order->get_type() && $order->get_meta( '_kco_recurring_token' ) ) {
+		if ( 'shop_subscription' === $order->get_type() && $order->get_meta( '_kco_recurring_token', true ) ) {
 			?>
 			<div class="order_data_column" style="clear:both; float:none; width:100%;">
 				<div class="address">
@@ -377,8 +390,9 @@ class KCO_Subscription {
 	public function save_kco_recurring_token_update( $post_id, $post ) {
 		$klarna_recurring_token = filter_input( INPUT_POST, '_kco_recurring_token', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$order                  = wc_get_order( $post_id );
-		if ( 'shop_subscription' === $order->get_type() && get_post_meta( $post_id, '_kco_recurring_token' ) ) {
-			update_post_meta( $post_id, '_kco_recurring_token', $klarna_recurring_token );
+		if ( 'shop_subscription' === $order->get_type() && $order->get_meta( '_kco_recurring_token', true ) ) {
+			$order->update_meta_data( '_kco_recurring_token', $klarna_recurring_token );
+			$order->save();
 		}
 
 	}
@@ -400,7 +414,10 @@ class KCO_Subscription {
 			$klarna_order = KCO_WC()->api->get_klarna_order( $klarna_order_id );
 			if ( ! is_wp_error( $klarna_order ) ) {
 				if ( isset( $klarna_order['recurring_token'] ) && ! empty( $klarna_order['recurring_token'] ) ) {
-					update_post_meta( $subscription_id, '_kco_recurring_token', sanitize_key( $klarna_order['recurring_token'] ) );
+					$subscription_order = wc_get_order( $subscription->get_id() );
+					$subscription_order->update_meta_data( '_kco_recurring_token', sanitize_key( $klarna_order['recurring_token'] ) );
+					$subscription_order->save();
+
 					// translators: %s Klarna recurring token.
 					$note = sprintf( __( 'Payment method changed via Klarna Checkout. New recurring token for subscription: %s', 'klarna-checkout-for-woocommerce' ), sanitize_key( $klarna_order['recurring_token'] ) );
 					$subscription->add_order_note( $note );
@@ -480,7 +497,13 @@ class KCO_Subscription {
 		$subscription->set_shipping_country( strtoupper( $klarna_order['shipping_address']['country'] ) );
 		$subscription->set_shipping_postcode( $klarna_order['shipping_address']['postal_code'] );
 		$subscription->set_shipping_city( $klarna_order['shipping_address']['city'] );
-		$subscription->set_shipping_phone( $klarna_order['shipping_address']['phone'] );
+
+		// NOTE: Since we declare support for WC v4+, and WC_Order::set_shipping_phone was only added in 5.6.0, we need to use update_meta_data instead. There is no default shipping email field in WC.
+		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '5.6.0', '>=' ) ) {
+			$subscription->set_shipping_phone( $klarna_order['shipping_address']['phone'] );
+		} else {
+			$subscription->update_meta_data( '_shipping_phone', $klarna_order['shipping_address']['phone'] );
+		}
 
 		$subscription->save();
 	}

--- a/classes/requests/checkout/post/class-kco-request-create.php
+++ b/classes/requests/checkout/post/class-kco-request-create.php
@@ -337,12 +337,19 @@ class KCO_Request_Create extends KCO_Request {
 			$address['country'] = $order->get_shipping_country();
 		}
 
-		$shipping_email = ! empty( get_post_meta( $order->get_id(), '_shipping_email', true ) ) ? get_post_meta( $order->get_id(), '_shipping_email', true ) : $order->get_billing_email();
+		$shipping_email = ! empty( $order->get_meta( '_shipping_email', true ) ) ? $order->get_meta( '_shipping_email', true ) : $order->get_billing_email();
 		if ( $shipping_email ) {
 			$address['email'] = $shipping_email;
 		}
 
-		$shipping_phone = ! empty( get_post_meta( $order->get_id(), '_shipping_phone', true ) ) ? get_post_meta( $order->get_id(), '_shipping_phone', true ) : $order->get_billing_phone();
+		// NOTE: Since we declare support for WC v4+, and WC_Order::get_shipping_phone was only added in 5.6.0, we need to use get_meta instead.
+		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '5.6.0', '>=' ) ) {
+			$shipping_phone = $order->get_shipping_phone();
+		} else {
+			$shipping_phone = $order->get_meta( '_shipping_phone', true );
+		}
+
+		$shipping_phone = ! empty( $shipping_phone ) ? $shipping_phone : $order->get_billing_phone();
 		if ( $shipping_phone ) {
 			$address['phone'] = $shipping_phone;
 		}

--- a/klarna-checkout-for-woocommerce.php
+++ b/klarna-checkout-for-woocommerce.php
@@ -265,6 +265,7 @@ if ( ! class_exists( 'KCO' ) ) {
 
 			load_plugin_textdomain( 'klarna-checkout-for-woocommerce', false, plugin_basename( __DIR__ ) . '/languages' );
 			add_filter( 'woocommerce_payment_gateways', array( $this, 'add_gateways' ) );
+			add_action( 'before_woocommerce_init', array( $this, 'declare_wc_compatability' ) );
 		}
 
 		/**
@@ -281,6 +282,17 @@ if ( ! class_exists( 'KCO' ) ) {
 			return $methods;
 		}
 
+		/**
+		 * Declare compatibility with WooCommerce features.
+		 *
+		 * @return void
+		 */
+		public function declare_wc_compatability() {
+			// Declare HPOS compatibility.
+			if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+				\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+			}
+		}
 
 		/**
 		 * Filters cart item quantity output.

--- a/klarna-checkout-for-woocommerce.php
+++ b/klarna-checkout-for-woocommerce.php
@@ -148,6 +148,16 @@ if ( ! class_exists( 'KCO' ) ) {
 		public function init() {
 			// Init the gateway itself.
 			$this->init_gateways();
+
+			// Declare HPOS compatibility.
+			add_action(
+				'before_woocommerce_init',
+				function() {
+					if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+						\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+					}
+				}
+			);
 		}
 
 		/**

--- a/klarna-checkout-for-woocommerce.php
+++ b/klarna-checkout-for-woocommerce.php
@@ -265,7 +265,7 @@ if ( ! class_exists( 'KCO' ) ) {
 
 			load_plugin_textdomain( 'klarna-checkout-for-woocommerce', false, plugin_basename( __DIR__ ) . '/languages' );
 			add_filter( 'woocommerce_payment_gateways', array( $this, 'add_gateways' ) );
-			add_action( 'before_woocommerce_init', array( $this, 'declare_wc_compatability' ) );
+			add_action( 'before_woocommerce_init', array( $this, 'declare_wc_compatibility' ) );
 		}
 
 		/**
@@ -287,7 +287,7 @@ if ( ! class_exists( 'KCO' ) ) {
 		 *
 		 * @return void
 		 */
-		public function declare_wc_compatability() {
+		public function declare_wc_compatibility() {
 			// Declare HPOS compatibility.
 			if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
 				\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );


### PR DESCRIPTION
As described in the [recipe book](https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book):
- `get_post( $post_id )` → `wc_get_order( $post_id )`
- `update_post_meta` → `WC_Order::update_meta_data`
- `add_post_meta` → `WC_Order::add_meta_data`
- `delete_post_meta` → `WC_Order::delete_meta_data`

Furthermore, where applicable, if a method is available for the meta field, that will be used in favor of retrieving it through the meta data function.  For example,  

```
get_post_meta($order_id, '_transaction_id', true)
```
is replaced with 
```
WC_Order::get_transaction_id()
```

If a meta data function is available, and update_meta_data is still used for that meta data, WooCommerce will warn about directly modifying internal meta data.

Note:
1. The HPOS-related methods _must_ be followed at some point by a `save()` call.
2. The recipe book does not seem to reference a replacement for `get_post_meta`, but this should be replaced by `WC_Order::get_meta`.