### PR TITLE
Check for retrieval only if data is an object or array

### DIFF
--- a/assets/js/klarna-checkout-for-woocommerce.js
+++ b/assets/js/klarna-checkout-for-woocommerce.js
@@ -307,7 +307,12 @@ jQuery( function( $ ) {
 		 * @param {array} data
 		 */
 		setCustomerData: function( data ) {
-			kco_wc.log( data );
+			kco_wc.log('setCustomerData', data );
+
+			if (typeof data !== 'object' || data === null) {
+				return;
+			}
+
 			if ( 'billing_address' in data && data.billing_address !== null ) {
 				// Billing fields.
 				$( '#billing_first_name' ).val( ( ( 'given_name' in data.billing_address ) ? data.billing_address.given_name : '' ) );


### PR DESCRIPTION
I suspect we receive `data = false` if the AJAX request succeeds, but the result is a failure. In other instances, we receive `data = bad_nonce`. This change should cover both cases.