### PR TITLE
Unblock form when modal closes

### DIFF
--- a/assets/js/klarna-checkout-for-woocommerce.js
+++ b/assets/js/klarna-checkout-for-woocommerce.js
@@ -56,7 +56,6 @@ jQuery( function( $ ) {
 					if ('attributes' === mutation.type && 'class' === mutation.attributeName) {
 						const modalClassName = 'klarna-checkout-fso-open';
 
-						// mutation.target.classList.contains('klarna-checkout-fso-open')
 						if (!$('html').hasClass(modalClassName)) {
 							// Wait for the Klarna modal to disappear before scrolling up to show error notices.
 							const noticeClassName = kco_params.pay_for_order ? 'div.woocommerce-notices-wrapper' : 'form.checkout';


### PR DESCRIPTION
When a customer places an order, the Klarna modal is displayed, and during this process, the order review table is blocked. However, if the customer closes the modal, Klarna does not notify us of this event. As a result, the order review table remains blocked indefinitely until the customer either changes the shipping option (if available) or refreshes the page.

To address this issue, we will implement a similar solution to the one used for resolving the problem of WooCommerce notifications not scrolling up when the modal is blocking the view. Specifically, we will check for the presence of the `klarna-checkout-fso-open` class, which indicates that the modal has been closed. Once we detect the closure of the modal, we will unblock the order review table.