### PR TITLE
Update order_id retrieved from meta query

### DIFF
--- a/classes/class-kco-confirmation.php
+++ b/classes/class-kco-confirmation.php
@@ -111,13 +111,17 @@ class KCO_Confirmation {
 			);
 
 			$order = reset( $orders );
+			if ( ! empty( $order ) ) {
+				$order_id = $order->get_id();
+			}
 		}
 
 		// Check if we have a order.
-		if ( ! $order ) {
+		if ( empty( $order ) ) {
 			wc_print_notice( __( 'Failed getting the order for the external payment.', 'klarna-checkout-for-woocommerce' ), 'error' );
 			return;
 		}
+
 		$payment_methods = WC()->payment_gateways->get_available_payment_gateways();
 		// Check if the payment method is available.
 		if ( ! isset( $payment_methods[ $epm ] ) ) {


### PR DESCRIPTION
Currently, when we retrieve the WC order through the meta query, we do not update the `$order_id` which remains `null` thus when we invoke the EPM's `process_method`, we're passing a `null` value.

- Update `order_id` retrieved from meta query