### PR TITLE
Fix issue with how we make meta queries when looking up orders

### DIFF
--- a/classes/class-kco-api-callbacks.php
+++ b/classes/class-kco-api-callbacks.php
@@ -68,19 +68,7 @@ class KCO_API_Callbacks {
 		// Used by Klarna_Checkout_Subscription::handle_push_cb_for_payment_method_change().
 		do_action( 'wc_klarna_push_cb', $klarna_order_id );
 
-		$orders = wc_get_orders(
-			array(
-				'meta_query' => array(
-					array(
-						'key'     => '_wc_klarna_order_id',
-						'value'   => $klarna_order_id,
-						'compare' => '=',
-					),
-				),
-			)
-		);
-
-		$order = reset( $orders );
+		$order = kco_get_order_by_klarna_id( $klarna_order_id );
 		if ( empty( $order ) ) {
 			// Backup order creation.
 			KCO_WC()->logger->log( 'ERROR Push callback but no existing WC order found for Klarna order ID ' . stripslashes_deep( wp_json_encode( $klarna_order_id ) ) );
@@ -143,19 +131,9 @@ class KCO_API_Callbacks {
 		$klarna_order_id = filter_input( INPUT_GET, 'kco_wc_order_id', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( ! empty( $klarna_order_id ) ) {
-			$orders = wc_get_orders(
-				array(
-					'meta_query' => array(
-						array(
-							'key'     => '_wc_klarna_order_id',
-							'value'   => $klarna_order_id,
-							'compare' => '=',
-						),
-					),
-				)
-			);
 
-			$order = reset( $orders );
+			$order = kco_get_order_by_klarna_id( $klarna_order_id );
+
 			if ( ! empty( $order ) ) {
 				$order_id = $order->get_id();
 			}

--- a/classes/class-kco-api.php
+++ b/classes/class-kco-api.php
@@ -74,21 +74,8 @@ class KCO_API {
 			$extracted_response = strstr( $response->get_error_message(), '}', true ) . '}';
 			$extracted_response = json_decode( $extracted_response );
 			if ( 'READ_ONLY_ORDER' === $extracted_response->error_code ) {
+				$order = kco_get_order_by_klarna_id( $klarna_order_id, '2 day ago' );
 
-				$orders = wc_get_orders(
-					array(
-						'meta_query' => array(
-							array(
-								'key'     => '_wc_klarna_order_id',
-								'value'   => $klarna_order_id,
-								'compare' => '=',
-							),
-						),
-						'date_after' => '2 day ago',
-					)
-				);
-
-				$order = reset( $orders );
 				if ( ! empty( $order ) ) {
 					wp_safe_redirect( $order->get_checkout_order_received_url() );
 					exit;

--- a/classes/class-kco-confirmation.php
+++ b/classes/class-kco-confirmation.php
@@ -97,20 +97,8 @@ class KCO_Confirmation {
 
 		// Try to retrieve the WC_Order using the Klarna order id.
 		if ( empty( $order ) && ! empty( $klarna_order_id ) ) {
-			$orders = wc_get_orders(
-				array(
-					'meta_query' => array(
-						array(
-							'key'     => '_wc_klarna_order_id',
-							'value'   => $klarna_order_id,
-							'compare' => '=',
-						),
-					),
-					'date_after' => '2 days ago',
-				)
-			);
+			$order = kco_get_order_by_klarna_id( $klarna_order_id, '2 day ago' );
 
-			$order = reset( $orders );
 			if ( ! empty( $order ) ) {
 				$order_id = $order->get_id();
 			}


### PR DESCRIPTION
Fixes #544

Also moves the logic for the validation of this to a single function, to not split functionality between different functions. Adds a verification that the order actually has the same metadata value stored in the order before we return it.