### PR TITLE
Improve logic when to fetch recurring token from Klarna

### DIFF
--- a/classes/class-kco-gateway.php
+++ b/classes/class-kco-gateway.php
@@ -508,6 +508,11 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 			// Set Klarna order ID.
 			$order->update_meta_data( '_wc_klarna_order_id', sanitize_key( $klarna_order['order_id'] ) );
 
+			// Set recurring order.
+			$kco_recurring_order = isset( $klarna_order['recurring'] ) && true === $klarna_order['recurring'] ? 'yes' : 'no';
+			$order->update_meta_data( '_kco_recurring_order', sanitize_key( $kco_recurring_order ) );
+
+			// Set recurring token if it exists.
 			if ( isset( $klarna_order['recurring_token'] ) ) {
 				$order->update_meta_data( '_kco_recurring_token', sanitize_key( $klarna_order['recurring_token'] ) );
 			}

--- a/classes/class-kco-subscription.php
+++ b/classes/class-kco-subscription.php
@@ -235,8 +235,10 @@ class KCO_Subscription {
 	 * @return void
 	 */
 	public function set_recurring_token_for_order( $order_id = null, $klarna_order = null ) {
-		$wc_order = wc_get_order( $order_id );
-		if ( class_exists( 'WC_Subscription' ) && ( wcs_order_contains_subscription( $wc_order, array( 'parent', 'renewal', 'resubscribe', 'switch' ) ) || wcs_is_subscription( $wc_order ) ) ) {
+		$wc_order        = wc_get_order( $order_id );
+		$recurring_order = $wc_order->get_meta( '_kco_recurring_order', true );
+
+		if ( 'yes' === $recurring_order || class_exists( 'WC_Subscription' ) && ( wcs_order_contains_subscription( $wc_order, array( 'parent', 'renewal', 'resubscribe', 'switch' ) ) || wcs_is_subscription( $wc_order ) ) ) {
 			$subscriptions   = wcs_get_subscriptions_for_order( $order_id, array( 'order_type' => 'any' ) );
 			$klarna_order_id = $wc_order->get_transaction_id();
 			$klarna_order    = KCO_WC()->api->get_klarna_order( $klarna_order_id );
@@ -248,6 +250,7 @@ class KCO_Subscription {
 
 				foreach ( $subscriptions as $subscription ) {
 					$subscription->update_meta_data( '_kco_recurring_token', $recurring_token );
+					$subscription->add_order_note( $note );
 
 					// Do not overwrite any existing phone number in case the customer has changed payment method (and thus shipping details).
 					if ( empty( $subscription->get_shipping_phone() ) ) {


### PR DESCRIPTION
Currently we do the following check if we should try to fetch a recurring token from Klarna:

```
if ( class_exists( 'WC_Subscription' ) && ( wcs_order_contains_subscription( $wc_order, array( 'parent', 'renewal', 'resubscribe', 'switch' ) ) || wcs_is_subscription( $wc_order ) ) ) {
}
```

In some cases it seems as this check is not true even though the customer is placing a subscription in Woo.

To improve this, we now add a meta data field during `process_payment()` where we save `_kco_recurring_order` as `yes` or `no`. We can then use this as an improved check if we should try to fetch the recurring token, like this:

```
$recurring_order = $wc_order->get_meta( '_kco_recurring_order', true );

if ( 'yes' === $recurring_order || class_exists( 'WC_Subscription' ) && ( wcs_order_contains_subscription( $wc_order, array( 'parent', 'renewal', 'resubscribe', 'switch' ) ) || wcs_is_subscription( $wc_order ) ) ) {
}
```

This PR also saves the received recurring token to subscription order notes.