### PR TITLE
Version 2.11.4

### DIFF
--- a/classes/admin/class-klarna-for-woocommerce-addons.php
+++ b/classes/admin/class-klarna-for-woocommerce-addons.php
@@ -70,15 +70,12 @@ if ( ! class_exists( 'Klarna_For_WooCommerce_Addons' ) ) {
 		 * Add the Addons options page to WooCommerce.
 		 **/
 		public function options_page() {
-			$tab     = filter_input( INPUT_GET, 'tab', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
-			$section = filter_input( INPUT_GET, 'section', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
-			$this->add_page_tabs( $tab );
-			if ( empty( $tab ) || 'addons' === $tab ) {
-				$addon_content = self::get_addons();
-				?>
-				<div id="checkout-addons-heading" class="checkout-addons-heading">
-				<div class="checkout-addons-wrap">
-				<h1><?php esc_html_e( 'Klarna Add-ons', 'klarna-checkout-for-woocommerce' ); ?></h1>
+			$section       = filter_input( INPUT_GET, 'section', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+			$addon_content = self::get_addons();
+			?>
+			<div id="checkout-addons-heading" class="checkout-addons-heading">
+			<div class="checkout-addons-wrap">
+			<h1><?php esc_html_e( 'Klarna Add-ons', 'klarna-checkout-for-woocommerce' ); ?></h1>
 			</div>
 			</div>
 				<?php if ( $addon_content->start ) : ?>
@@ -124,12 +121,6 @@ if ( ! class_exists( 'Klarna_For_WooCommerce_Addons' ) ) {
 				<?php endif; ?>
 			</div>
 				<?php
-			} elseif ( 'settings' === $tab ) {
-				do_action( 'klarna_addons_settings_tab', $section );
-				?>
-				<p><?php esc_html_e( 'Please install an add-on to be able to see the settings.', 'klarna-checkout-for-woocommerce' ); ?></p>
-				<?php
-			}
 		}
 
 		/**
@@ -380,29 +371,6 @@ if ( ! class_exists( 'Klarna_For_WooCommerce_Addons' ) ) {
 			if ( is_object( $addons ) ) {
 				return $addons;
 			}
-		}
-
-		/**
-		 * Adds tabs to the Addons page.
-		 *
-		 * @param string $current Wich tab is to be selected.
-		 * @return void
-		 */
-		public function add_page_tabs( $current = 'addons' ) {
-			if ( empty( $current ) ) {
-				$current = 'addons';
-			}
-			$tabs = array(
-				'addons'   => __( 'Klarna Add-ons', 'klarna-checkout-for-woocommerce' ),
-				'settings' => __( 'Settings', 'klarna-checkout-for-woocommerce' ),
-			);
-			$html = '<h2 class="nav-tab-wrapper">';
-			foreach ( $tabs as $tab => $name ) {
-				$class = ( $tab === $current ) ? 'nav-tab-active' : '';
-				$html .= '<a class="nav-tab ' . $class . '" href="?page=checkout-addons&tab=' . $tab . '">' . $name . '</a>';
-			}
-			$html .= '</h2>';
-			echo $html; // phpcs:ignore WordPress.Security.EscapeOutput
 		}
 	}
 }

--- a/classes/class-kco-gateway.php
+++ b/classes/class-kco-gateway.php
@@ -508,6 +508,11 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 			// Set Klarna order ID.
 			$order->update_meta_data( '_wc_klarna_order_id', sanitize_key( $klarna_order['order_id'] ) );
 
+			// Set recurring order.
+			$kco_recurring_order = isset( $klarna_order['recurring'] ) && true === $klarna_order['recurring'] ? 'yes' : 'no';
+			$order->update_meta_data( '_kco_recurring_order', sanitize_key( $kco_recurring_order ) );
+
+			// Set recurring token if it exists.
 			if ( isset( $klarna_order['recurring_token'] ) ) {
 				$order->update_meta_data( '_kco_recurring_token', sanitize_key( $klarna_order['recurring_token'] ) );
 			}

--- a/classes/class-kco-gateway.php
+++ b/classes/class-kco-gateway.php
@@ -411,13 +411,14 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 					'kco_order_id'           => $klarna_order_id,
 					'wc_order_shipping'      => $order->get_shipping_method(),
 					'wc_session_shipping'    => WC()->session->get( 'chosen_shipping_methods' ),
-					'kco_order_shipping'     => $klarna_order['selected_shipping_option'],
+					// selected_shipping_option is only available if shipping is displayed in iframe.
+					'kco_order_shipping'     => $klarna_order['selected_shipping_option'] ?? 'N/A',
 					'kco_shipping_transient' => get_transient( "kss_data_$klarna_order_id" ),
 				);
 				$data               = json_encode( $shipping_debug_log );
 				KCO_Logger::log( "Extra shipping debug: $data" );
 			} catch ( Exception $e ) {
-				KCO_Logger::log( 'Extra shipping debug: Error generating log' );
+				KCO_Logger::log( 'Extra shipping debug: Error generating log due to ' . $e->getMessage() );
 			}
 			// ----- Extra Debug Logging End ----- //
 

--- a/classes/class-kco-gateway.php
+++ b/classes/class-kco-gateway.php
@@ -408,10 +408,10 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 			// ----- Extra Debug Logging Start ----- //
 			try {
 				$shipping_debug_log = array(
-					'kco_order_id'          => $klarna_order_id,
-					'wc_order_shipping'     => $order->get_shipping_method(),
-					'wc_session_shipping'   => WC()->session->get( 'chosen_shipping_methods' ),
-					'kco_order_shipping'    => $klarna_order['selected_shipping_option'],
+					'kco_order_id'           => $klarna_order_id,
+					'wc_order_shipping'      => $order->get_shipping_method(),
+					'wc_session_shipping'    => WC()->session->get( 'chosen_shipping_methods' ),
+					'kco_order_shipping'     => $klarna_order['selected_shipping_option'],
 					'kco_shipping_transient' => get_transient( "kss_data_$klarna_order_id" ),
 				);
 				$data               = json_encode( $shipping_debug_log );
@@ -422,7 +422,9 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 			// ----- Extra Debug Logging End ----- //
 
 			if ( ! $klarna_order ) {
-				return false;
+				return array(
+					'result' => 'error',
+				);
 			}
 
 			if ( $order_id && $klarna_order ) {

--- a/classes/class-kco-settings-saved.php
+++ b/classes/class-kco-settings-saved.php
@@ -50,40 +50,42 @@ class KCO_Settings_Saved {
 			return;
 		}
 
-		// Check EU Production.
-		if ( '' !== $options['merchant_id_eu'] ) {
-			$username = $options['merchant_id_eu'];
-			$password = $options['shared_secret_eu'];
+		if ( 'yes' !== $options['testmode'] ) {
+			// Check EU Production.
+			if ( '' !== $options['merchant_id_eu'] ) {
+				$username = $options['merchant_id_eu'];
+				$password = $options['shared_secret_eu'];
 
-			$test_response = ( new KCO_Request_Test_Credentials() )->request( $username, $password, false, 'EU' );
-			$this->process_test_response( $test_response, self::EU_PROD );
-		}
+				$test_response = ( new KCO_Request_Test_Credentials() )->request( $username, $password, false, 'EU' );
+				$this->process_test_response( $test_response, self::EU_PROD );
+			}
 
-		// Check EU Test.
-		if ( '' !== $options['test_merchant_id_eu'] ) {
-			$username = $options['test_merchant_id_eu'];
-			$password = $options['test_shared_secret_eu'];
+			// Check US Production.
+			if ( '' !== $options['merchant_id_us'] ) {
+				$username = $options['merchant_id_us'];
+				$password = $options['shared_secret_us'];
 
-			$test_response = ( new KCO_Request_Test_Credentials() )->request( $username, $password, true, 'EU' );
-			$this->process_test_response( $test_response, self::EU_TEST );
-		}
+				$test_response = ( new KCO_Request_Test_Credentials() )->request( $username, $password, false, 'US' );
+				$this->process_test_response( $test_response, self::US_PROD );
+			}
+		} else {
+			// Check EU Test.
+			if ( '' !== $options['test_merchant_id_eu'] ) {
+				$username = $options['test_merchant_id_eu'];
+				$password = $options['test_shared_secret_eu'];
 
-		// Check US Production.
-		if ( '' !== $options['merchant_id_us'] ) {
-			$username = $options['merchant_id_us'];
-			$password = $options['shared_secret_us'];
+				$test_response = ( new KCO_Request_Test_Credentials() )->request( $username, $password, true, 'EU' );
+				$this->process_test_response( $test_response, self::EU_TEST );
+			}
 
-			$test_response = ( new KCO_Request_Test_Credentials() )->request( $username, $password, false, 'US' );
-			$this->process_test_response( $test_response, self::US_PROD );
-		}
+			// Check US Test.
+			if ( '' !== $options['test_merchant_id_us'] ) {
+				$username = $options['test_merchant_id_us'];
+				$password = $options['test_shared_secret_us'];
 
-		// Check US Test.
-		if ( '' !== $options['test_merchant_id_us'] ) {
-			$username = $options['test_merchant_id_us'];
-			$password = $options['test_shared_secret_us'];
-
-			$test_response = ( new KCO_Request_Test_Credentials() )->request( $username, $password, true, 'US' );
-			$this->process_test_response( $test_response, self::US_TEST );
+				$test_response = ( new KCO_Request_Test_Credentials() )->request( $username, $password, true, 'US' );
+				$this->process_test_response( $test_response, self::US_TEST );
+			}
 		}
 
 		$this->maybe_handle_error();
@@ -108,7 +110,7 @@ class KCO_Settings_Saved {
 		if ( 401 === $code || 403 === $code ) {
 			switch ( $code ) {
 				case 401:
-					$message = "It seems like your Klarna $test credentials are incorrect, please verify or remove these credentials and save again. ";
+					$message = "Your Klarna $test credentials not authorized. Please verify the credentials and environment (production or test mode) or remove these credentials and save again. API credentials only work in either production or test, not both environments. ";
 					break;
 				case 403:
 					$message = "It seems like your Klarna $test API credentials are not working for the Klarna Checkout plugin, please verify your Klarna contract is for the Klarna Checkout solution.  If your Klarna contract is for standalone payment methods, please instead use the <a href='https://docs.woocommerce.com/document/klarna-payments/'>Klarna Payments for WooCommerce</a> plugin. ";

--- a/classes/class-kco-subscription.php
+++ b/classes/class-kco-subscription.php
@@ -235,8 +235,10 @@ class KCO_Subscription {
 	 * @return void
 	 */
 	public function set_recurring_token_for_order( $order_id = null, $klarna_order = null ) {
-		$wc_order = wc_get_order( $order_id );
-		if ( class_exists( 'WC_Subscription' ) && ( wcs_order_contains_subscription( $wc_order, array( 'parent', 'renewal', 'resubscribe', 'switch' ) ) || wcs_is_subscription( $wc_order ) ) ) {
+		$wc_order        = wc_get_order( $order_id );
+		$recurring_order = $wc_order->get_meta( '_kco_recurring_order', true );
+
+		if ( 'yes' === $recurring_order || class_exists( 'WC_Subscription' ) && ( wcs_order_contains_subscription( $wc_order, array( 'parent', 'renewal', 'resubscribe', 'switch' ) ) || wcs_is_subscription( $wc_order ) ) ) {
 			$subscriptions   = wcs_get_subscriptions_for_order( $order_id, array( 'order_type' => 'any' ) );
 			$klarna_order_id = $wc_order->get_transaction_id();
 			$klarna_order    = KCO_WC()->api->get_klarna_order( $klarna_order_id );
@@ -248,6 +250,7 @@ class KCO_Subscription {
 
 				foreach ( $subscriptions as $subscription ) {
 					$subscription->update_meta_data( '_kco_recurring_token', $recurring_token );
+					$subscription->add_order_note( $note );
 
 					// Do not overwrite any existing phone number in case the customer has changed payment method (and thus shipping details).
 					if ( empty( $subscription->get_shipping_phone() ) ) {

--- a/classes/class-kco-subscription.php
+++ b/classes/class-kco-subscription.php
@@ -34,6 +34,7 @@ class KCO_Subscription {
 		add_action( 'wc_klarna_push_cb', array( $this, 'handle_push_cb_for_payment_method_change' ) );
 		add_action( 'init', array( $this, 'display_thankyou_message_for_payment_method_change' ) );
 		add_action( 'woocommerce_account_view-subscription_endpoint', array( $this, 'maybe_confirm_change_payment_method' ) );
+		add_filter( 'allowed_redirect_hosts', array( $this, 'extend_allowed_domains_list' ) );
 
 	}
 
@@ -515,6 +516,19 @@ class KCO_Subscription {
 		}
 
 		$subscription->save();
+	}
+
+	/**
+	 * Add Klarna hosted payment page as allowed external url for wp_safe_redirect.
+	 * We do this because WooCommerce Subscriptions use wp_safe_redirect when processing a payment method change request (from v5.1.0).
+	 *
+	 * @param array $hosts Domains that are allowed when wp_safe_redirect is used.
+	 * @return array
+	 */
+	public function extend_allowed_domains_list( $hosts ) {
+		$hosts[] = 'pay.playground.klarna.com';
+		$hosts[] = 'pay.klarna.com';
+		return $hosts;
 	}
 }
 new KCO_Subscription();

--- a/klarna-checkout-for-woocommerce.php
+++ b/klarna-checkout-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Klarna Checkout payment gateway for WooCommerce.
  * Author: Krokedil
  * Author URI: https://krokedil.com/
- * Version: 2.11.3
+ * Version: 2.11.4
  * Text Domain: klarna-checkout-for-woocommerce
  * Domain Path: /languages
  *
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'KCO_WC_VERSION', '2.11.3' );
+define( 'KCO_WC_VERSION', '2.11.4' );
 define( 'KCO_WC_MIN_PHP_VER', '5.6.0' );
 define( 'KCO_WC_MIN_WC_VER', '3.9.0' );
 define( 'KCO_WC_MAIN_FILE', __FILE__ );

--- a/klarna-checkout-for-woocommerce.php
+++ b/klarna-checkout-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Klarna Checkout payment gateway for WooCommerce.
  * Author: Krokedil
  * Author URI: https://krokedil.com/
- * Version: 2.11.2
+ * Version: 2.11.3
  * Text Domain: klarna-checkout-for-woocommerce
  * Domain Path: /languages
  *
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'KCO_WC_VERSION', '2.11.2' );
+define( 'KCO_WC_VERSION', '2.11.3' );
 define( 'KCO_WC_MIN_PHP_VER', '5.6.0' );
 define( 'KCO_WC_MIN_WC_VER', '3.9.0' );
 define( 'KCO_WC_MAIN_FILE', __FILE__ );

--- a/languages/klarna-checkout-for-woocommerce.pot
+++ b/languages/klarna-checkout-for-woocommerce.pot
@@ -8,7 +8,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language-Team: Krokedil <info@krokedil.se>\n"
 "Last-Translator: Krokedil <info@krokedil.se>\n"
-"POT-Creation-Date: 2023-06-26 13:43+0000\n"
+"POT-Creation-Date: 2023-07-18 12:07+0000\n"
 "Report-Msgid-Bugs-To: http://krokedil.se\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;_ex:1,2c;_n:1,2;_n_noop:1,2;_nx:1,2,4c;_nx_noop:1,2,3c;_x:1,2c;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c\n"
@@ -26,15 +26,15 @@ msgid "Support"
 msgstr ""
 
 #. translators: Klarna order ID.
-#: ../classes/class-kco-api-callbacks.php:111, ../includes/kco-functions.php:617
+#: ../classes/class-kco-api-callbacks.php:99, ../includes/kco-functions.php:617
 msgid "Klarna order is under review, order ID: %s."
 msgstr ""
 
-#: ../classes/class-kco-api-callbacks.php:108
+#: ../classes/class-kco-api-callbacks.php:96
 msgid "Klarna Checkout order was rejected."
 msgstr ""
 
-#: ../classes/class-kco-api-callbacks.php:104, ../includes/kco-functions.php:609
+#: ../classes/class-kco-api-callbacks.php:92, ../includes/kco-functions.php:609
 msgid "Payment via Klarna Checkout, order ID: %s"
 msgstr ""
 
@@ -42,15 +42,15 @@ msgstr ""
 msgid "The shipping methods have been changed during the checkout process. Please verify your selected shipping method and try again."
 msgstr ""
 
-#: ../classes/class-kco-confirmation.php:121
+#: ../classes/class-kco-confirmation.php:109
 msgid "Failed getting the order for the external payment."
 msgstr ""
 
-#: ../classes/class-kco-confirmation.php:128
+#: ../classes/class-kco-confirmation.php:116
 msgid "Failed to find the payment method for the external payment."
 msgstr ""
 
-#: ../classes/class-kco-confirmation.php:138
+#: ../classes/class-kco-confirmation.php:126
 msgid "Something went wrong with the external payment. Please try again"
 msgstr ""
 
@@ -435,19 +435,19 @@ msgstr ""
 msgid "Please try again, something went wrong with processing your order."
 msgstr ""
 
-#: ../classes/class-kco-gateway.php:482
+#: ../classes/class-kco-gateway.php:485
 msgid "Customer redirected to Klarna Hosted Payment Page."
 msgstr ""
 
-#: ../classes/class-kco-gateway.php:580
+#: ../classes/class-kco-gateway.php:583
 msgid "Order address should not be changed and any changes you make will not be reflected in Klarna system."
 msgstr ""
 
-#: ../classes/class-kco-gateway.php:639
+#: ../classes/class-kco-gateway.php:642
 msgid "Organisation number:"
 msgstr ""
 
-#: ../classes/class-kco-gateway.php:661, ../classes/class-kco-gateway.php:683
+#: ../classes/class-kco-gateway.php:664, ../classes/class-kco-gateway.php:686
 msgid "Reference:"
 msgstr ""
 
@@ -455,7 +455,7 @@ msgstr ""
 msgid "Klarna Checkout for WooCommerce"
 msgstr ""
 
-#: ../classes/class-kco-subscription.php:269
+#: ../classes/class-kco-subscription.php:268
 msgid "Recurring token was missing from the Klarna order during the checkout process. Please contact Klarna for help."
 msgstr ""
 
@@ -464,27 +464,27 @@ msgid "Recurring token for subscription: %s"
 msgstr ""
 
 #. translators: Error message.
-#: ../classes/class-kco-subscription.php:345
+#: ../classes/class-kco-subscription.php:344
 msgid "Subscription payment failed with Klarna. Message: %1$s"
 msgstr ""
 
-#: ../classes/class-kco-subscription.php:338
+#: ../classes/class-kco-subscription.php:337
 msgid "Subscription payment made with Klarna. Klarna order id: %s"
 msgstr ""
 
-#: ../classes/class-kco-subscription.php:372
+#: ../classes/class-kco-subscription.php:381
 msgid "Klarna recurring token"
 msgstr ""
 
-#: ../classes/class-kco-subscription.php:428
+#: ../classes/class-kco-subscription.php:437
 msgid "Could not retrieve new Klarna recurring token for subscription when customer changed payment method. Read the log for detailed information."
 msgstr ""
 
-#: ../classes/class-kco-subscription.php:422
+#: ../classes/class-kco-subscription.php:431
 msgid "Payment method changed via Klarna Checkout. New recurring token for subscription: %s"
 msgstr ""
 
-#: ../classes/class-kco-subscription.php:449
+#: ../classes/class-kco-subscription.php:458
 msgid "Thank you, your subscription payment method is now updated."
 msgstr ""
 

--- a/languages/klarna-checkout-for-woocommerce.pot
+++ b/languages/klarna-checkout-for-woocommerce.pot
@@ -8,7 +8,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language-Team: Krokedil <info@krokedil.se>\n"
 "Last-Translator: Krokedil <info@krokedil.se>\n"
-"POT-Creation-Date: 2023-07-18 12:07+0000\n"
+"POT-Creation-Date: 2023-07-26 12:01+0000\n"
 "Report-Msgid-Bugs-To: http://krokedil.se\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;_ex:1,2c;_n:1,2;_n_noop:1,2;_nx:1,2,4c;_nx_noop:1,2,3c;_x:1,2c;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c\n"
@@ -17,7 +17,7 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../klarna-checkout-for-woocommerce.php:173, ../classes/admin/class-klarna-for-woocommerce-addons.php:397
+#: ../klarna-checkout-for-woocommerce.php:173
 msgid "Settings"
 msgstr ""
 
@@ -439,15 +439,15 @@ msgstr ""
 msgid "Customer redirected to Klarna Hosted Payment Page."
 msgstr ""
 
-#: ../classes/class-kco-gateway.php:583
+#: ../classes/class-kco-gateway.php:588
 msgid "Order address should not be changed and any changes you make will not be reflected in Klarna system."
 msgstr ""
 
-#: ../classes/class-kco-gateway.php:642
+#: ../classes/class-kco-gateway.php:647
 msgid "Organisation number:"
 msgstr ""
 
-#: ../classes/class-kco-gateway.php:664, ../classes/class-kco-gateway.php:686
+#: ../classes/class-kco-gateway.php:669, ../classes/class-kco-gateway.php:691
 msgid "Reference:"
 msgstr ""
 
@@ -455,36 +455,36 @@ msgstr ""
 msgid "Klarna Checkout for WooCommerce"
 msgstr ""
 
-#: ../classes/class-kco-subscription.php:268
+#: ../classes/class-kco-subscription.php:272
 msgid "Recurring token was missing from the Klarna order during the checkout process. Please contact Klarna for help."
 msgstr ""
 
-#: ../classes/class-kco-subscription.php:245
+#: ../classes/class-kco-subscription.php:248
 msgid "Recurring token for subscription: %s"
 msgstr ""
 
 #. translators: Error message.
-#: ../classes/class-kco-subscription.php:344
+#: ../classes/class-kco-subscription.php:348
 msgid "Subscription payment failed with Klarna. Message: %1$s"
 msgstr ""
 
-#: ../classes/class-kco-subscription.php:337
+#: ../classes/class-kco-subscription.php:341
 msgid "Subscription payment made with Klarna. Klarna order id: %s"
 msgstr ""
 
-#: ../classes/class-kco-subscription.php:381
+#: ../classes/class-kco-subscription.php:385
 msgid "Klarna recurring token"
 msgstr ""
 
-#: ../classes/class-kco-subscription.php:437
+#: ../classes/class-kco-subscription.php:441
 msgid "Could not retrieve new Klarna recurring token for subscription when customer changed payment method. Read the log for detailed information."
 msgstr ""
 
-#: ../classes/class-kco-subscription.php:431
+#: ../classes/class-kco-subscription.php:435
 msgid "Payment method changed via Klarna Checkout. New recurring token for subscription: %s"
 msgstr ""
 
-#: ../classes/class-kco-subscription.php:458
+#: ../classes/class-kco-subscription.php:462
 msgid "Thank you, your subscription payment method is now updated."
 msgstr ""
 
@@ -534,27 +534,23 @@ msgstr ""
 msgid "It looks as if you don't have pretty permalinks enabled in WordPress. For Klarna checkout for WooCommerce to function properly, this needs to be enabled. "
 msgstr ""
 
-#: ../classes/admin/class-klarna-for-woocommerce-addons.php:66, ../classes/admin/class-klarna-for-woocommerce-addons.php:66, ../classes/admin/class-klarna-for-woocommerce-addons.php:81, ../classes/admin/class-klarna-for-woocommerce-addons.php:396
+#: ../classes/admin/class-klarna-for-woocommerce-addons.php:66, ../classes/admin/class-klarna-for-woocommerce-addons.php:66, ../classes/admin/class-klarna-for-woocommerce-addons.php:78
 msgid "Klarna Add-ons"
 msgstr ""
 
-#: ../classes/admin/class-klarna-for-woocommerce-addons.php:130
-msgid "Please install an add-on to be able to see the settings."
-msgstr ""
-
-#: ../classes/admin/class-klarna-for-woocommerce-addons.php:186
+#: ../classes/admin/class-klarna-for-woocommerce-addons.php:177
 msgid "Install"
 msgstr ""
 
-#: ../classes/admin/class-klarna-for-woocommerce-addons.php:186
+#: ../classes/admin/class-klarna-for-woocommerce-addons.php:177
 msgid "Not installed"
 msgstr ""
 
-#: ../classes/admin/class-klarna-for-woocommerce-addons.php:189
+#: ../classes/admin/class-klarna-for-woocommerce-addons.php:180
 msgid "Activated"
 msgstr ""
 
-#: ../classes/admin/class-klarna-for-woocommerce-addons.php:192
+#: ../classes/admin/class-klarna-for-woocommerce-addons.php:183
 msgid "Deactivated"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -54,6 +54,12 @@ Klarna Checkout works for merchants in Sweden, Finland, Norway, Germany, Austria
 For help setting up and configuring Klarna Checkout for WooCommerce please refer to our [documentation](https://docs.krokedil.com/klarna-checkout-for-woocommerce/).
 
 == Changelog ==
+= 2023.07.26    - version 2.11.4 =
+* Fix           - Resolved an issue related to redirection when changing or updating the subscription payment method. Now, Klarna's hosted payment page has been added to the list of allowed external URLs for 'wp_safe_redirect' function.
+* Fix           - Addressed an issue where the recurring token was not being saved appropriately. This was occurring because the orders containing subscriptions were not being correctly identified.
+* Tweak         - Removed the settings tab from the “Klarna Add-ons” page because its functionalities have been transferred to the plugin.
+* Tweak         - We will now validate the API credentials based on the active mode, whether it’s test or production. This enhancement should prevent the plugin from inaccurately attempting to verify production credentials when the test mode is in operation.
+
 = 2023.07.18    - version 2.11.3 =
 * Fix           - Fixed an issue where the recurring token was no longer being displayed in the billing fields.
 * Fix           - Fixed an undefined index warning that ocurred when the shipping was shown outside of the iframe.

--- a/readme.txt
+++ b/readme.txt
@@ -54,6 +54,11 @@ Klarna Checkout works for merchants in Sweden, Finland, Norway, Germany, Austria
 For help setting up and configuring Klarna Checkout for WooCommerce please refer to our [documentation](https://docs.krokedil.com/klarna-checkout-for-woocommerce/).
 
 == Changelog ==
+= 2023.07.18    - version 2.11.3 =
+* Fix           - Fixed an issue where the recurring token was no longer being displayed in the billing fields.
+* Fix           - Fixed an undefined index warning that ocurred when the shipping was shown outside of the iframe.
+* Fix           - When processing a payment, and the order is not found, we'll now return the response in the expected format. 
+
 = 2023.06.28    - version 2.11.2 =
 * Fix           - Fixed an issue with how we made our meta queries when trying to find orders based on a Klarna order ID.
 * Enhancement   - Added a validation to ensure that the order returned by our meta query actually is the correct order by verifying that the Klarna order ID stored matches the one we searched for.


### PR DESCRIPTION
* Fix           - Resolved an issue related to redirection when changing or updating the subscription payment method. Now, Klarna's hosted payment page has been added to the list of allowed external URLs for 'wp_safe_redirect' function.
* Fix           - Addressed an issue where the recurring token was not being saved appropriately. This was occurring because the orders containing subscriptions were not being correctly identified.
* Tweak         - Removed the settings tab from the “Klarna Add-ons” page because its functionalities have been transferred to the plugin.
* Tweak         - We will now validate the API credentials based on the active mode, whether it’s test or production. This enhancement should prevent the plugin from inaccurately attempting to verify production credentials when the test mode is in operation.