### PR TITLE
Add extra logging when processing order

### DIFF
--- a/assets/js/klarna-checkout-for-woocommerce.js
+++ b/assets/js/klarna-checkout-for-woocommerce.js
@@ -451,7 +451,7 @@ jQuery( function( $ ) {
 
   placeKlarnaOrder: function(callback) {
 			kco_wc.getKlarnaOrder().done( function(response) {
-				if(response.success ) {
+				if( response.success ) {
 					$( '.woocommerce-checkout-review-order-table' ).block({
 						message: null,
 						overlayCSS: {
@@ -466,8 +466,15 @@ jQuery( function( $ ) {
 						dataType: 'json',
 						success: function( data ) {
 							try {
-								if ( 'success' === data.result ) {
-									kco_wc.logToFile( 'Successfully placed order. Sending "should_proceed: true" to Klarna' );
+								if ('success' === data.result) {
+									let email = 'N/A'
+									if ('billing_address' in response.data && 'email' in response.data.billing_address) {
+										email = response.data.shipping_address.email;
+									} else if ('shipping_address' in response.data && 'email' in response.data.shipping_address) { 
+										email = response.data.shipping_address.email;
+									}
+
+									kco_wc.logToFile( 'Successfully placed order [' + email + ']. Sending "should_proceed: true" to Klarna' );
 									callback({ should_proceed: true });
 								} else {
 									throw 'Result failed';

--- a/languages/klarna-checkout-for-woocommerce.pot
+++ b/languages/klarna-checkout-for-woocommerce.pot
@@ -8,7 +8,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Language-Team: Krokedil <info@krokedil.se>\n"
 "Last-Translator: Krokedil <info@krokedil.se>\n"
-"POT-Creation-Date: 2023-07-26 12:01+0000\n"
+"POT-Creation-Date: 2023-08-01 17:07+0000\n"
 "Report-Msgid-Bugs-To: http://krokedil.se\n"
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-KeywordsList: __;_e;_ex:1,2c;_n:1,2;_n_noop:1,2;_nx:1,2,4c;_nx_noop:1,2,3c;_x:1,2c;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c\n"
@@ -427,27 +427,27 @@ msgstr ""
 msgid "The current Klarna Checkout replaces standard WooCommerce checkout page."
 msgstr ""
 
-#: ../classes/class-kco-gateway.php:267
+#: ../classes/class-kco-gateway.php:266
 msgid "Please fill in all required checkout fields."
 msgstr ""
 
-#: ../classes/class-kco-gateway.php:270
+#: ../classes/class-kco-gateway.php:269
 msgid "Please try again, something went wrong with processing your order."
 msgstr ""
 
-#: ../classes/class-kco-gateway.php:485
+#: ../classes/class-kco-gateway.php:489
 msgid "Customer redirected to Klarna Hosted Payment Page."
 msgstr ""
 
-#: ../classes/class-kco-gateway.php:588
+#: ../classes/class-kco-gateway.php:592
 msgid "Order address should not be changed and any changes you make will not be reflected in Klarna system."
 msgstr ""
 
-#: ../classes/class-kco-gateway.php:647
+#: ../classes/class-kco-gateway.php:651
 msgid "Organisation number:"
 msgstr ""
 
-#: ../classes/class-kco-gateway.php:669, ../classes/class-kco-gateway.php:691
+#: ../classes/class-kco-gateway.php:673, ../classes/class-kco-gateway.php:695
 msgid "Reference:"
 msgstr ""
 


### PR DESCRIPTION
- add the customer's email address to identify the successful order in the log.
- when processing payment on the backend, add extra logging for successful and failed processing attempts.