### PR TITLE
Handle situations when HTML snippet not available

### DIFF
--- a/classes/class-kco-templates.php
+++ b/classes/class-kco-templates.php
@@ -150,6 +150,7 @@ class KCO_Templates {
 				return;
 			}
 
+			wc_add_notice( __( 'Klarna Checkout is not available. Please choose a different payment option or contact the store for assistance.', 'klarna-checkout-for-woocommerce' ), 'error' );
 			$available_gateways = WC()->payment_gateways()->get_available_payment_gateways();
 			// Do not redirect if KCO is the only available gateway to prevent infinite loop.
 			if ( 1 === count( $available_gateways ) ) {


### PR DESCRIPTION
This concerns the issue where the template fails to load when it is not returned in the create session request as an HTML snippet, which prevents the customer from proceeding to the checkout page. This is an issue if the store offers other payment methods, since the customer won't be able to pay with those in this situation.

- if KCO is the only available gateway, notify the customer but remain on the checkout page.
- if there is an alternative gateway, switch to it and notify the customer that KCO is not available.

Related task: https://app.clickup.com/t/3wg79zp