### PR TITLE
Prevent order status change on callback once processed once

### DIFF
--- a/classes/class-kco-api-callbacks.php
+++ b/classes/class-kco-api-callbacks.php
@@ -85,7 +85,7 @@ class KCO_API_Callbacks {
 			);
 
 			// The Woo order was already created. Check if order status was set (in process_payment_handler).
-			if ( ! $order->has_status( array( 'processing', 'completed' ) ) ) {
+			if ( empty( $order->get_date_paid() ) ) {
 				if ( 'ACCEPTED' === $klarna_order['fraud_status'] ) {
 					$order->payment_complete( $klarna_order_id );
 					// translators: Klarna order ID.


### PR DESCRIPTION
`WC_Order::get_date_paid` is true if the payment has been completed which covers cases for when the order status is cancelled or refunded.