### PR TITLE
Retrieve order id through WC order

### DIFF
--- a/classes/class-kco-confirmation.php
+++ b/classes/class-kco-confirmation.php
@@ -50,6 +50,7 @@ class KCO_Confirmation {
 	public function confirm_order() {
 		$kco_confirm     = filter_input( INPUT_GET, 'kco_confirm', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$klarna_order_id = filter_input( INPUT_GET, 'kco_order_id', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		$order_id        = filter_input( INPUT_GET, 'order_id', FILTER_SANITIZE_NUMBER_INT );
 		$order_key       = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		// Return if we dont have our parameters set.
@@ -57,7 +58,12 @@ class KCO_Confirmation {
 			return;
 		}
 
-		$order_id = wc_get_order_id_by_order_key( $order_key );
+		if ( ! empty( $order_id ) ) {
+			$order    = wc_get_order( $order_id );
+			$order_id = ! empty( $order ) && hash_equals( $order->get_order_key(), $order_key ) ? absint( $order_id ) : wc_get_order_id_by_order_key( $order_key );
+		} else {
+			$order_id = wc_get_order_id_by_order_key( $order_key );
+		}
 
 		// Return if we cant find an order id.
 		if ( empty( $order_id ) ) {

--- a/classes/requests/checkout/post/class-kco-request-update-confirmation.php
+++ b/classes/requests/checkout/post/class-kco-request-update-confirmation.php
@@ -63,6 +63,7 @@ class KCO_Request_Update_Confirmation extends KCO_Request {
 			array(
 				'kco_confirm'  => 'yes',
 				'kco_order_id' => '{checkout.order.id}',
+				'order_id'     => $order_id,
 			),
 			$order->get_checkout_order_received_url()
 		);

--- a/classes/requests/helpers/class-kco-merchant-urls.php
+++ b/classes/requests/helpers/class-kco-merchant-urls.php
@@ -82,6 +82,7 @@ class KCO_Merchant_URLs {
 				array(
 					'kco_confirm'  => 'yes',
 					'kco_order_id' => '{checkout.order.id}',
+					'order_id'     => $order_id,
 				),
 				$order->get_checkout_order_received_url()
 			);
@@ -123,7 +124,6 @@ class KCO_Merchant_URLs {
 		$shipping_option_update_url = str_replace( 'http:', 'https:', $shipping_option_update_url );
 
 		return apply_filters( 'kco_wc_shipping_option_update_url', $shipping_option_update_url );
-
 	}
 
 	/**
@@ -140,7 +140,6 @@ class KCO_Merchant_URLs {
 		$address_update_url = str_replace( 'http:', 'https:', $address_update_url );
 
 		return apply_filters( 'kco_wc_address_update_url', $address_update_url );
-
 	}
 
 	/**


### PR DESCRIPTION
`wc_get_order_id_by_order_key` has terrible performance on databases with many orders when HPOS is not enabled.

- pass order ID where applicable.