### PR TITLE
Use first country available as billing country for subscriptions

### DIFF
--- a/classes/class-kco-gateway.php
+++ b/classes/class-kco-gateway.php
@@ -181,7 +181,22 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 			// If we have a subscription product in cart and the customer isn't from SE, NO, FI, DE, DK, AT or NL, disable KCO.
 			if ( is_checkout() && class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) {
 				$available_recurring_countries = array( 'SE', 'NO', 'FI', 'DK', 'DE', 'AT', 'NL' );
-				if ( ! in_array( WC()->customer->get_billing_country(), $available_recurring_countries, true ) ) {
+				$country                       = WC()->customer->get_billing_country();
+				if ( empty( $country ) ) {
+					// If the billing country is not available, the "No location by default" setting is set.
+					// By default, if there is exactly one country the store sells to, it will be used by default.
+					// However, it still won't be set as the billing country until the customer has filled their billing address.
+					// In practice, the customer doesn't really have any other choice, so we can assume that it is selected country.
+					$countries = WC()->countries->get_allowed_countries();
+					if ( 1 === count( $countries ) ) {
+						$country = array_key_first( $countries );
+					} elseif ( 1 < count( $countries ) ) {
+						// If there is at least more than one allowed country, WC will let the customer pick a country on the checkout page.
+						// We'll wait until the customer has made a choice.
+						return false;
+					}
+				}
+				if ( ! in_array( $country, $available_recurring_countries, true ) ) {
 					return false;
 				}
 			}


### PR DESCRIPTION
If the merchant set the default location to "No location by default", no billing country will be specified in the checkout page which affects customers whose billing country is not set in their account, and all guests. 

Usually, if the store only serves one country, WooCommerce automatically selects that country. However, the billing country won't be set until the customer provides their billing address. Given that there is only one option available to the customer, we can assume that it will be the selected country.

**This issue only affects subscriptions, since we need to check the billing country to determine whether subscriptions should be available.**

https://app.clickup.com/t/86941jdcx