### PR TITLE
Display the Woo error message inside the Klarna modal

### DIFF
--- a/assets/js/klarna-checkout-for-woocommerce.js
+++ b/assets/js/klarna-checkout-for-woocommerce.js
@@ -436,7 +436,7 @@ jQuery( function ( $ ) {
 		 * @param {string} event
 		 */
 		failOrder: function ( event, error_message, callback ) {
-			callback( { should_proceed: false } )
+			callback( { should_proceed: false, message: $(error_message).text().trim() } )
 			kco_wc.validation = false
 			var className = kco_params.pay_for_order ? "div.woocommerce-notices-wrapper" : "form.checkout"
 			// Update the checkout and re-enable the form.


### PR DESCRIPTION
When the customer clicks on the buy button, the `validation_callback`  event will be triggered. Initially, I thought we could perform validation before we respond, but at this point, the modal is already open, and there is no event that is in-between the click event and the modal opening. Thus, we cannot prevent it from appearing. However, there is a different option: we can display the error message inside the modal (see screenshot) which is what this PR addresses.

![image](https://github.com/krokedil/klarna-checkout-for-woocommerce/assets/26507935/bac09a00-3302-495b-beb5-092ffbfe4080)

If multiple checkout errors happens, it won't look very pretty, though.

![image](https://github.com/krokedil/klarna-checkout-for-woocommerce/assets/26507935/dcb90a0c-26fb-4c20-8bb4-da660bb19346)

And we cannot send any marking in the text since Klarna escapes all HTML, so we have to remove it.

![image](https://github.com/krokedil/klarna-checkout-for-woocommerce/assets/26507935/202fc805-b30d-46ac-81a4-73d58bc9ed81)

task: https://app.clickup.com/t/8694jn5hy