### PR TITLE
Fix order quantity mismatch due to integer vs double type

### DIFF
--- a/includes/kco-functions.php
+++ b/includes/kco-functions.php
@@ -710,7 +710,7 @@ function kco_validate_order_content( $klarna_order, $order ) {
 			$match = false;
 			if ( $reference === $klarna_order_item['reference'] ) {
 				$match = true;
-				if ( ( (int) $klarna_order_item['quantity'] ) !== ( (int) $order_line['quantity'] ) ) {
+				if ( $klarna_order_item['quantity'] != $order_line['quantity'] ) {
 					// translators: %1$s: Product name, %2$d: Expected quantity, %3$d: Found quantity.
 					$notes[] = sprintf( __( 'The product "%1$s" has a quantity mismatch. Expected %2$d found %3$d.', 'klarna-checkout-for-woocommerce' ), $name, $klarna_order_item['quantity'], $order_line['quantity'] );
 					KCO_Logger::log( "$prefix WC order item reference: $reference ($name) has {$order_line['quantity']} expected {$klarna_order_item['quantity']}." );

--- a/includes/kco-functions.php
+++ b/includes/kco-functions.php
@@ -710,7 +710,7 @@ function kco_validate_order_content( $klarna_order, $order ) {
 			$match = false;
 			if ( $reference === $klarna_order_item['reference'] ) {
 				$match = true;
-				if ( $klarna_order_item['quantity'] !== $order_line['quantity'] ) {
+				if ( ( (int) $klarna_order_item['quantity'] ) !== ( (int) $order_line['quantity'] ) ) {
 					// translators: %1$s: Product name, %2$d: Expected quantity, %3$d: Found quantity.
 					$notes[] = sprintf( __( 'The product "%1$s" has a quantity mismatch. Expected %2$d found %3$d.', 'klarna-checkout-for-woocommerce' ), $name, $klarna_order_item['quantity'], $order_line['quantity'] );
 					KCO_Logger::log( "$prefix WC order item reference: $reference ($name) has {$order_line['quantity']} expected {$klarna_order_item['quantity']}." );


### PR DESCRIPTION
Latest version caused an invalid mismatch where `$klarna_order_item['quantity']` was an integer and `$order_line['quantity']` was a double.