### PR TITLE
Check for errors before triggering scroll on order submit

### DIFF
--- a/assets/js/klarna-checkout-for-woocommerce.js
+++ b/assets/js/klarna-checkout-for-woocommerce.js
@@ -56,16 +56,21 @@ jQuery( function ( $ ) {
 					if ( "attributes" === mutation.type && "class" === mutation.attributeName ) {
 						if ( ! $( "html" ).hasClass( modalClassName ) ) {
 							if ( modalWasOpen ) {
-								// Wait for the Klarna modal to disappear before scrolling up to show error notices.
+								// Wait for the Klarna modal to disappear before checking if any errors are found.
 								const noticeClassName = kco_params.pay_for_order
 									? "div.woocommerce-notices-wrapper"
-									: "form.checkout"
-								$( "html, body" ).animate(
-									{
-										scrollTop: $( noticeClassName ).offset().top - 100,
-									},
-									1000,
-								)
+									: "form.checkout";
+								const notices = $( noticeClassName );
+
+								// Scroll to error notices if found.
+								if ( notices.length && notices.find( ".woocommerce-error" ).length ) {
+									$( "html, body" ).animate(
+										{
+											scrollTop: notices.offset().top - 100,
+										},
+										1000
+									);
+								}
 
 								// Unlock the order review table and checkout form.
 								kco_wc.unblock()


### PR DESCRIPTION
Add check to see if errors exists before triggering scroll to errors, after Klarna order submit.