### PR TITLE
Adding DE to allowed_customer_types

### DIFF
--- a/classes/class-kco-fields.php
+++ b/classes/class-kco-fields.php
@@ -246,7 +246,7 @@ class KCO_Fields {
 					'B2CB' => __( 'B2C & B2B (defaults to B2C)', 'klarna-checkout-for-woocommerce' ),
 					'B2BC' => __( 'B2B & B2C (defaults to B2B)', 'klarna-checkout-for-woocommerce' ),
 				),
-				'description' => __( 'Select if you want to sell both to consumers and companies or only to one of them (available for SE, NO and FI). You need to contact Klarna directly to activate this with your account.', 'klarna-checkout-for-woocommerce' ),
+				'description' => __( 'Select if you want to sell both to consumers and companies or only to one of them (available for SE, NO, FI and DE). You need to contact Klarna directly to activate this with your account.', 'klarna-checkout-for-woocommerce' ),
 				'default'     => 'B2C',
 				'desc_tip'    => false,
 			),

--- a/classes/requests/helpers/class-kco-request-options.php
+++ b/classes/requests/helpers/class-kco-request-options.php
@@ -118,7 +118,7 @@ class KCO_Request_Options {
 	 */
 	private function get_allowed_customer_types() {
 
-		if ( in_array( $this->get_purchase_country(), array( 'SE', 'NO', 'FI' ), true ) && isset( $this->settings['allowed_customer_types'] ) ) {
+		if ( in_array( $this->get_purchase_country(), array( 'SE', 'NO', 'FI', 'DE' ), true ) && isset( $this->settings['allowed_customer_types'] ) ) {
 			$customer_types_setting = $this->settings['allowed_customer_types'];
 
 			switch ( $customer_types_setting ) {


### PR DESCRIPTION
The setting for allowed_customer_types has been updated to now also include DE (Germany).