### PR TITLE
Skip state validation

### DIFF
--- a/classes/class-kco-gateway.php
+++ b/classes/class-kco-gateway.php
@@ -119,7 +119,7 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 				'address_1'  => 'street_address',
 				'address_2'  => 'street_address2',
 				'city'       => 'city',
-				'state'      => 'region',
+				// 'state'      => 'region',
 				'postcode'   => 'postal_code',
 				'country'    => 'country',
 			);


### PR DESCRIPTION
There doesn't seem to be a standard naming convention for country states. E.g., the state of Dublin in Woo is "D" (or "Dublin") whereas in Klarna it is "Co. Dublin". Furthermore, the way you enter the state in Woo is through a select dropdown, whereas in Klarna it must be typed unless autocompleted.

https://app.clickup.com/t/8695nt5cy