### PR TITLE
Check if no payment option is available

### DIFF
--- a/assets/js/klarna-checkout-for-woocommerce.js
+++ b/assets/js/klarna-checkout-for-woocommerce.js
@@ -31,13 +31,15 @@ jQuery( function ( $ ) {
 		 * Triggers on document ready.
 		 */
 		documentReady: function () {
-			kco_wc.log( kco_params )
 			if ( 0 < kco_wc.paymentMethodEl.length ) {
 				kco_wc.paymentMethod = kco_wc.paymentMethodEl.filter( ":checked" ).val()
-			} else {
+			} else if( 0 < $('ul.wc_payment_methods').length ) {
 				kco_wc.paymentMethod = "kco"
+			} else {
+				return;
 			}
 
+			kco_wc.log( kco_params )
 			if ( "kco" === kco_wc.paymentMethod ) {
 				$( "#ship-to-different-address-checkbox" ).prop( "checked", true )
 			}


### PR DESCRIPTION
Check if no payment option is available before running KCO code on document ready in checkout.

Question 1:
Perhaps this is a bigger issue; should the JS file as a whole not be included in the checkout if no payment option is available?

Question 2:
Is `ul.wc_payment_methods` a bad target, should WooCommerce change the class name? I see that we target quite a bit of WooCommerce classes though, so this might be fine.