### PR TITLE
Add check before displaying pay button

### DIFF
--- a/classes/class-kco-gateway.php
+++ b/classes/class-kco-gateway.php
@@ -84,7 +84,6 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 			// Body class for KSS.
 			add_filter( 'body_class', array( $this, 'add_body_class' ) );
 
-			add_filter( 'woocommerce_order_needs_payment', array( $this, 'maybe_change_needs_payment' ), 999, 3 );
 			add_filter( 'kco_wc_api_request_args', array( $this, 'maybe_remove_kco_epm' ), 9999 );
 
 			// Prevent the Woo validation from proceeding if there is a discrepancy between Woo and Klarna.
@@ -823,29 +822,6 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 					<?php
 				}
 			}
-		}
-
-
-		/**
-		 * Maybe change the needs payment for a WooCommerce order.
-		 *
-		 * @param bool     $wc_result The result WooCommerce had.
-		 * @param WC_Order $order The WooCommerce order.
-		 * @param array    $valid_order_statuses The valid order statuses.
-		 * @return bool
-		 */
-		public function maybe_change_needs_payment( $wc_result, $order, $valid_order_statuses ) {
-			// Only change for KCO orders.
-			if ( 'kco' !== $order->get_payment_method() ) {
-				return $wc_result;
-			}
-
-			// Only if our filter is active and is set to false.
-			if ( apply_filters( 'kco_check_if_needs_payment', true ) ) {
-				return $wc_result;
-			}
-
-			return true;
 		}
 
 		/**


### PR DESCRIPTION
Only display the pay button on the order-pay page, to avoid displaying it on the order received page.