### PR TITLE
Addresses PHP warning due to missing 'status'

### DIFF
--- a/classes/class-kco-api.php
+++ b/classes/class-kco-api.php
@@ -159,7 +159,7 @@ class KCO_API {
 	 * Checks for WP Errors and returns either the response as array or a false.
 	 *
 	 * @param array|WP_Error $response The response from the request.
-	 * @return mixed
+	 * @return array|false The response array or false if there was an error.
 	 */
 	private function check_for_api_error( $response ) {
 		if ( is_wp_error( $response ) ) {

--- a/classes/class-kco-api.php
+++ b/classes/class-kco-api.php
@@ -46,7 +46,7 @@ class KCO_API {
 	 * Gets a Klarna Checkout order
 	 *
 	 * @param string $klarna_order_id The Klarna Checkout order id.
-	 * @return mixed
+	 * @return array|false
 	 */
 	public function get_klarna_order( $klarna_order_id ) {
 		$request  = new KCO_Request_Retrieve();
@@ -158,7 +158,7 @@ class KCO_API {
 	/**
 	 * Checks for WP Errors and returns either the response as array or a false.
 	 *
-	 * @param array $response The response from the request.
+	 * @param array|WP_Error $response The response from the request.
 	 * @return mixed
 	 */
 	private function check_for_api_error( $response ) {

--- a/classes/class-kco-checkout.php
+++ b/classes/class-kco-checkout.php
@@ -108,17 +108,18 @@ class KCO_Checkout {
 		}
 
 		$klarna_order = KCO_WC()->api->get_klarna_order( $klarna_order_id );
+		if ( ! $klarna_order ) {
+			return;
+		}
 
-		// Store the status in case it is omitted from the response in the update request.
-		$status = $klarna_order['status'] ?? null;
-		if ( $klarna_order && 'checkout_incomplete' === $status ) {
+		if ( 'checkout_incomplete' === $klarna_order['status'] ) {
 			// If it is, update order.
-			$klarna_order = KCO_WC()->api->update_klarna_order( $klarna_order_id );
-			$status       = $klarna_order['status'] ?? $status;
+			$updated_klarna_order = KCO_WC()->api->update_klarna_order( $klarna_order_id );
 		}
 
 		// If cart doesn't need payment anymore - reload the checkout page.
 		if ( apply_filters( 'kco_check_if_needs_payment', true ) ) {
+			$status = $updated_klarna_order ? $updated_klarna_order['status'] : $klarna_order['status'];
 			if ( ! WC()->cart->needs_payment() && 'checkout_incomplete' === $status ) {
 				WC()->session->reload_checkout = true;
 			}

--- a/classes/class-kco-checkout.php
+++ b/classes/class-kco-checkout.php
@@ -117,10 +117,6 @@ class KCO_Checkout {
 		if ( 'checkout_incomplete' === $klarna_order['status'] ) {
 			// If it is, update order.
 			$updated_klarna_order = KCO_WC()->api->update_klarna_order( $klarna_order_id );
-			if ( ! $updated_klarna_order ) {
-				KCO_Logger::log( "Klarna order could not be updated during update for ID: $klarna_order_id " );
-				return;
-			}
 		}
 
 		// If cart doesn't need payment anymore - reload the checkout page.

--- a/classes/class-kco-checkout.php
+++ b/classes/class-kco-checkout.php
@@ -110,7 +110,7 @@ class KCO_Checkout {
 		$klarna_order = KCO_WC()->api->get_klarna_order( $klarna_order_id );
 
 		// Store the status in case it is omitted from the response in the update request.
-		$status = $klarna_order['status'];
+		$status = $klarna_order['status'] ?? null;
 		if ( $klarna_order && 'checkout_incomplete' === $status ) {
 			// If it is, update order.
 			$klarna_order = KCO_WC()->api->update_klarna_order( $klarna_order_id );

--- a/classes/class-kco-checkout.php
+++ b/classes/class-kco-checkout.php
@@ -109,14 +109,17 @@ class KCO_Checkout {
 
 		$klarna_order = KCO_WC()->api->get_klarna_order( $klarna_order_id );
 
-		if ( $klarna_order && 'checkout_incomplete' === $klarna_order['status'] ) {
+		// Store the status in case it is omitted from the response in the update request.
+		$status = $klarna_order['status'];
+		if ( $klarna_order && 'checkout_incomplete' === $status ) {
 			// If it is, update order.
 			$klarna_order = KCO_WC()->api->update_klarna_order( $klarna_order_id );
+			$status       = $klarna_order['status'] ?? $status;
 		}
 
 		// If cart doesn't need payment anymore - reload the checkout page.
 		if ( apply_filters( 'kco_check_if_needs_payment', true ) ) {
-			if ( ! WC()->cart->needs_payment() && 'checkout_incomplete' === $klarna_order['status'] ) {
+			if ( ! WC()->cart->needs_payment() && 'checkout_incomplete' === $status ) {
 				WC()->session->reload_checkout = true;
 			}
 		}

--- a/classes/class-kco-checkout.php
+++ b/classes/class-kco-checkout.php
@@ -109,12 +109,17 @@ class KCO_Checkout {
 
 		$klarna_order = KCO_WC()->api->get_klarna_order( $klarna_order_id );
 		if ( ! $klarna_order ) {
+			KCO_Logger::log( "Klarna order could not be retrieved during update for ID: $klarna_order_id " );
 			return;
 		}
 
 		if ( 'checkout_incomplete' === $klarna_order['status'] ) {
 			// If it is, update order.
 			$updated_klarna_order = KCO_WC()->api->update_klarna_order( $klarna_order_id );
+			if ( ! $updated_klarna_order ) {
+				KCO_Logger::log( "Klarna order could not be updated during update for ID: $klarna_order_id " );
+				return;
+			}
 		}
 
 		// If cart doesn't need payment anymore - reload the checkout page.

--- a/classes/class-kco-checkout.php
+++ b/classes/class-kco-checkout.php
@@ -113,6 +113,7 @@ class KCO_Checkout {
 			return;
 		}
 
+		$updated_klarna_order = false;
 		if ( 'checkout_incomplete' === $klarna_order['status'] ) {
 			// If it is, update order.
 			$updated_klarna_order = KCO_WC()->api->update_klarna_order( $klarna_order_id );

--- a/classes/requests/checkout/post/class-kco-request-update.php
+++ b/classes/requests/checkout/post/class-kco-request-update.php
@@ -19,7 +19,7 @@ class KCO_Request_Update extends KCO_Request {
 	 * @param string $klarna_order_id The Klarna order id.
 	 * @param int    $order_id The WooCommerce order id.
 	 * @param bool   $force If true always update the order, even if not needed.
-	 * @return array|false
+	 * @return array|false|WP_Error
 	 */
 	public function request( $klarna_order_id, $order_id = null, $force = false ) {
 		$request_url  = $this->get_api_url_base() . 'checkout/v3/orders/' . $klarna_order_id;

--- a/classes/requests/checkout/post/class-kco-request-update.php
+++ b/classes/requests/checkout/post/class-kco-request-update.php
@@ -19,7 +19,7 @@ class KCO_Request_Update extends KCO_Request {
 	 * @param string $klarna_order_id The Klarna order id.
 	 * @param int    $order_id The WooCommerce order id.
 	 * @param bool   $force If true always update the order, even if not needed.
-	 * @return array
+	 * @return array|false
 	 */
 	public function request( $klarna_order_id, $order_id = null, $force = false ) {
 		$request_url  = $this->get_api_url_base() . 'checkout/v3/orders/' . $klarna_order_id;
@@ -31,14 +31,14 @@ class KCO_Request_Update extends KCO_Request {
 		}
 		WC()->session->set( 'kco_update_md5', md5( wp_json_encode( $request_args ) ) );
 
-		$response          = wp_remote_request( $request_url, $request_args );
-		$code              = wp_remote_retrieve_response_code( $response );
-		$formated_response = $this->process_response( $response, $request_args, $request_url );
+		$response           = wp_remote_request( $request_url, $request_args );
+		$code               = wp_remote_retrieve_response_code( $response );
+		$formatted_response = $this->process_response( $response, $request_args, $request_url );
 
 		// Log the request.
 		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO update order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
 		KCO_Logger::log( $log );
-		return $formated_response;
+		return $formatted_response;
 	}
 
 	/**

--- a/classes/requests/class-kco-request.php
+++ b/classes/requests/class-kco-request.php
@@ -144,17 +144,18 @@ class KCO_Request {
 		}
 
 		// Check the status code, if its not between 200 and 299 then its an error.
-		if ( wp_remote_retrieve_response_code( $response ) < 200 || wp_remote_retrieve_response_code( $response ) > 299 ) {
-			$data          = 'URL: ' . $request_url . ' - ' . wp_json_encode( $request_args );
+		$code = wp_remote_retrieve_response_code( $response );
+		if ( $code < 200 || $code > 299 ) {
+			$data          = "URL: $request_url - " . wp_json_encode( $request_args );
 			$error_message = '';
 			// Get the error messages.
 			if ( null !== json_decode( $response['body'], true ) ) {
 				$errors = json_decode( $response['body'], true );
 				foreach ( $errors['error_messages'] as $error ) {
-					$error_message = $error_message . ' ' . $error;
+					$error_message = "$error_message $error";
 				}
 			}
-			return new WP_Error( wp_remote_retrieve_response_code( $response ), $response['body'] . $error_message, $data );
+			return new WP_Error( $code, $response['body'] . $error_message, $data );
 		}
 		return json_decode( wp_remote_retrieve_body( $response ), true );
 	}


### PR DESCRIPTION
The `status` is not always returned in the response from Klarna.

```
Got error 'PHP message: PHP Warning:  Trying to access array offset on false in plugins/klarna-checkout-for-woocommerce/classes/class-kco-checkout.php on line 118
```

However, based on this error message, it is the `update_klarna_order` call that removes the `status`. Otherwise, the warning should have appeared [on line 112](https://github.com/krokedil/klarna-checkout-for-woocommerce/blob/develop/classes/class-kco-checkout.php#L112).

I suggest we either store the status like I've done in this PR, and only update it if it exists in the new response, or we only overwrite the `$klarna_order` if the result is non-`false`.

https://app.clickup.com/t/8698w3rbb