### PR TITLE
Switch API domain for Kustom onboarded merchants

### DIFF
--- a/classes/class-kco-credentials.php
+++ b/classes/class-kco-credentials.php
@@ -27,7 +27,27 @@ class KCO_Credentials {
 	 * KCO_Credentials constructor.
 	 */
 	public function __construct() {
-		$this->settings = get_option( 'woocommerce_kco_settings' );
+		$this->settings = get_option( 'woocommerce_kco_settings', array() );
+		add_filter( 'kco_api_domain', array( $this, 'maybe_set_api_domain' ) );
+	}
+
+	/**
+	 * Uses the setting to see if we should force the API domain or let the automatic function handle it.
+	 *
+	 * @param string $api_domain The API domain to use.
+	 *
+	 * @return string The domain to use for the request.
+	 */
+	public function maybe_set_api_domain( $api_domain ) {
+		$api_domain_setting = $this->settings['api_domain'] ?? '';
+
+		// If the setting is empty, use the value passed in the filter.
+		if ( empty( $api_domain_setting ) ) {
+			return $api_domain;
+		}
+
+		// If the setting is not empty, use the value from the setting.
+		return $api_domain_setting;
 	}
 
 	/**

--- a/classes/class-kco-fields.php
+++ b/classes/class-kco-fields.php
@@ -87,6 +87,21 @@ class KCO_Fields {
 				'default'  => 'two_column_right',
 				'desc_tip' => false,
 			),
+			'api_domain' => array(
+				'title'       => __( 'API Endpoint', 'klarna-checkout-for-woocommerce' ),
+				'type'        => 'select',
+				'description' => __( 'Select the API endpoint to use for Klarna Checkout. For stores that have created their API credentials through the Kustom portal, the API endpoint needs to be set to kustom.co instead of klarna.com. If you use the default option, the plugin will attempt to determine this automatically. But you can force the endpoint by using this setting if this is incorrect.', 'klarna-checkout-for-woocommerce' ),
+				'default'     => '',
+				'options'     => array(
+					__('Recommended', 'klarna-checkout-for-woocommerce') => array(
+						'' => __( 'Use plugin logic (default)', 'klarna-checkout-for-woocommerce' ),
+					),
+					__('Force specific endpoint', 'klarna-checkout-for-woocommerce') => array(
+						'klarna.com' => __( 'Force klarna.com endpoint', 'klarna-checkout-for-woocommerce' ),
+						'kustom.co' => __( 'Force kustom.co endpoint', 'klarna-checkout-for-woocommerce' ),
+					),
+				),
+			),
 			// EU.
 			'credentials_eu'             => array(
 				'title' => '<img src="' . KCO_WC_PLUGIN_URL . '/assets/img/flags/eu.svg height="12" /> API Credentials Europe',

--- a/classes/requests/checkout/post/class-kco-request-test-credentials.php
+++ b/classes/requests/checkout/post/class-kco-request-test-credentials.php
@@ -89,12 +89,13 @@ class KCO_Request_Test_Credentials extends KCO_Request {
 	 * @param bool   $testmode If its test mode or not.
 	 * @param string $endpoint The endpoint for the request.
 	 * @param string $username The username to use.
+	 * @param string $password The password to use.
 	 *
 	 */
 	public function get_test_endpoint( $testmode, $endpoint, $username, $password ) {
 		$country_string = 'US' === $endpoint ? '-na' : '';
 		$test_string    = $testmode ? '.playground' : '';
-		$domain 		= KCO_Request::get_api_domain( $username, $password );
+		$domain 		= KCO_Request::get_api_domain( $password, $username );
 
 		return "https://api{$country_string}{$test_string}.{$domain}/";
 	}

--- a/classes/requests/checkout/post/class-kco-request-test-credentials.php
+++ b/classes/requests/checkout/post/class-kco-request-test-credentials.php
@@ -23,16 +23,16 @@ class KCO_Request_Test_Credentials extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $username, $password, $testmode, $endpoint ) {
-		$request_url       = $this->get_test_endpoint( $testmode, $endpoint ) . 'checkout/v3/orders';
+		$request_url       = $this->get_test_endpoint( $testmode, $endpoint, $username ) . 'checkout/v3/orders';
 		$request_args      = apply_filters( 'kco_wc_test_credentials', $this->get_request_args( $username, $password ) );
 		$response          = wp_remote_request( $request_url, $request_args );
 		$code              = wp_remote_retrieve_response_code( $response );
-		$formated_response = $this->process_response( $response, $request_args, $request_url );
+		$formatted_response = $this->process_response( $response, $request_args, $request_url );
 
 		// Log the request.
 		$log = KCO_Logger::format_log( null, 'POST', 'KCO test credentials', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
 		KCO_Logger::log( $log );
-		return $formated_response;
+		return $formatted_response;
 	}
 
 	/**
@@ -88,12 +88,15 @@ class KCO_Request_Test_Credentials extends KCO_Request {
 	 *
 	 * @param bool   $testmode If its test mode or not.
 	 * @param string $endpoint The endpoint for the request.
+	 * @param string $username The username to use.
+	 *
 	 */
-	public function get_test_endpoint( $testmode, $endpoint ) {
+	public function get_test_endpoint( $testmode, $endpoint, $username ) {
 		$country_string = 'US' === $endpoint ? '-na' : '';
 		$test_string    = $testmode ? '.playground' : '';
+		$domain 		= KCO_Request::get_api_domain( $username );
 
-		return 'https://api' . $country_string . $test_string . '.klarna.com/';
+		return "https://api{$country_string}{$test_string}.{$domain}/";
 	}
 
 	/**

--- a/classes/requests/checkout/post/class-kco-request-test-credentials.php
+++ b/classes/requests/checkout/post/class-kco-request-test-credentials.php
@@ -23,7 +23,7 @@ class KCO_Request_Test_Credentials extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $username, $password, $testmode, $endpoint ) {
-		$request_url       = $this->get_test_endpoint( $testmode, $endpoint, $username ) . 'checkout/v3/orders';
+		$request_url       = $this->get_test_endpoint( $testmode, $endpoint, $username, $password ) . 'checkout/v3/orders';
 		$request_args      = apply_filters( 'kco_wc_test_credentials', $this->get_request_args( $username, $password ) );
 		$response          = wp_remote_request( $request_url, $request_args );
 		$code              = wp_remote_retrieve_response_code( $response );
@@ -91,10 +91,10 @@ class KCO_Request_Test_Credentials extends KCO_Request {
 	 * @param string $username The username to use.
 	 *
 	 */
-	public function get_test_endpoint( $testmode, $endpoint, $username ) {
+	public function get_test_endpoint( $testmode, $endpoint, $username, $password ) {
 		$country_string = 'US' === $endpoint ? '-na' : '';
 		$test_string    = $testmode ? '.playground' : '';
-		$domain 		= KCO_Request::get_api_domain( $username );
+		$domain 		= KCO_Request::get_api_domain( $username, $password );
 
 		return "https://api{$country_string}{$test_string}.{$domain}/";
 	}

--- a/classes/requests/class-kco-request.php
+++ b/classes/requests/class-kco-request.php
@@ -55,15 +55,29 @@ class KCO_Request {
 	/**
 	 * Get the domain to use for the request based on the merchant ID.
 	 *
+	 * @param string $password The Klarna shared secret.
 	 * @param string $merchant_id The Klarna merchant ID.
 	 *
 	 * @return string The domain to use for the request.
 	 */
-	public static function get_api_domain( $merchant_id ) {
-		// If the merchant ID starts with either M or PM, we need to use the Kustom domain instead.
-		$pattern = '/^(M|PM)/';
-		$domain = preg_match( $pattern, $merchant_id ) ? 'kustom.co' : 'klarna.com';
-		return apply_filters( 'kco_api_domain', $domain );
+	public static function get_api_domain( $password, $merchant_id ) {
+		// If the password starts with 'kco_', or the mid starts with 'M' or 'PM', use kustom.co, otherwise use klarna.com.
+		$password_pattern = '/^kco_/';
+		$mid_pattern = '/^(M|PM)/';
+
+		$domain = 'klarna.com';
+		if ( preg_match( $password_pattern, $password ) || preg_match( $mid_pattern, $merchant_id ) ) {
+			$domain = 'kustom.co';
+		}
+
+		$domain = apply_filters( 'kco_api_domain', $domain, $merchant_id );
+
+		// Ensure the return domain is a valid string, and remove any leading or trailing whitespace or slashes.
+		if ( ! is_string( $domain ) || empty( $domain ) ) {
+			$domain = 'klarna.com';
+		}
+
+		return trim( $domain, " \t\n\r\0\x0B/" );
 	}
 
 	/**
@@ -73,7 +87,7 @@ class KCO_Request {
 		$base_location  = wc_get_base_location();
 		$country_string = 'US' === $base_location['country'] ? '-na' : '';
 		$test_string    = 'yes' === $this->settings['testmode'] ? '.playground' : '';
-		$domain = KCO_Request::get_api_domain( $this->get_merchant_id() );
+		$domain = KCO_Request::get_api_domain( $this->get_shared_secret(), $this->get_merchant_id() );
 
 		return "https://api{$country_string}{$test_string}.{$domain}/";
 	}

--- a/classes/requests/class-kco-request.php
+++ b/classes/requests/class-kco-request.php
@@ -53,14 +53,29 @@ class KCO_Request {
 	}
 
 	/**
+	 * Get the domain to use for the request based on the merchant ID.
+	 *
+	 * @param string $merchant_id The Klarna merchant ID.
+	 *
+	 * @return string The domain to use for the request.
+	 */
+	public static function get_api_domain( $merchant_id ) {
+		// If the merchant ID starts with either M or PM, we need to use the Kustom domain instead.
+		$pattern = '/^(M|PM)/';
+		$domain = preg_match( $pattern, $merchant_id ) ? 'kustom.co' : 'klarna.com';
+		return apply_filters( 'kco_api_domain', $domain );
+	}
+
+	/**
 	 * Gets Klarna API URL base.
 	 */
 	public function get_api_url_base() {
 		$base_location  = wc_get_base_location();
 		$country_string = 'US' === $base_location['country'] ? '-na' : '';
 		$test_string    = 'yes' === $this->settings['testmode'] ? '.playground' : '';
+		$domain = KCO_Request::get_api_domain( $this->get_merchant_id() );
 
-		return 'https://api' . $country_string . $test_string . '.klarna.com/';
+		return "https://api{$country_string}{$test_string}.{$domain}/";
 	}
 
 	/**


### PR DESCRIPTION
New merchants onboarding through Kustoms portal will have a MID that start with M in production or PM in playground.
From 13/6 2025 these new credentials will require all requests to go through the `kustom.co` domain instead of `klarna.com` following the same structure for playground and regions. In cases where merchants have special MIDs, there is also a filter added to support setting the domain manually if needed.

------

* Tweak - API Usernames that start with either M for production or PM for playground will use the `kustom.co` domain instead of `klarna.com` for all API requests. The domain can be changed using the filter `kco_api_domain` to set this manually if needed.