### PR TITLE
Addresses unsupported operand types: string + <numeric type> errors introduce in WC 9.9.x

### DIFF
--- a/classes/requests/helpers/class-kco-request-shipping-options.php
+++ b/classes/requests/helpers/class-kco-request-shipping-options.php
@@ -37,20 +37,18 @@ class KCO_Request_Shipping_Options {
 					continue;
 				}
 
-				$method_cost = floatval( $method->cost );
-				if ( $separate_sales_tax ) {
-					$method_price = intval( round( $method_cost, 2 ) * 100 );
-				} else {
-					$method_price = intval( round( $method_cost + array_sum( $method->taxes ), 2 ) * 100 );
-				}
+				$method_cost  = floatval( $method->cost );
+				$method_taxes = array_sum( $method->taxes );
+				$method_price = intval( round( $method_cost + ( $separate_sales_tax ? 0 : $method_taxes ), 2 ) * 100 );
 
-				if ( array_sum( $method->taxes ) > 0 && ( ! $separate_sales_tax ) ) {
-					$method_tax_amount = intval( round( array_sum( $method->taxes ), 2 ) * 100 );
-					$method_tax_rate   = intval( round( ( array_sum( $method->taxes ) / $method_cost ) * 100, 2 ) * 100 );
+				if ( $method_taxes > 0 && ! $separate_sales_tax ) {
+					$method_tax_amount = intval( round( $method_taxes, 2 ) * 100 );
+					$method_tax_rate   = intval( round( ( $method_taxes / $method_cost ) * 100, 2 ) * 100 );
 				} else {
 					$method_tax_amount = 0;
 					$method_tax_rate   = 0;
 				}
+
 				$method_selected    = $method->id === $chosen_method ? true : false;
 				$shipping_options[] = array(
 					'id'          => $method_id,

--- a/classes/requests/helpers/class-kco-request-shipping-options.php
+++ b/classes/requests/helpers/class-kco-request-shipping-options.php
@@ -37,15 +37,16 @@ class KCO_Request_Shipping_Options {
 					continue;
 				}
 
+				$method_cost = floatval( $method->cost );
 				if ( $separate_sales_tax ) {
-					$method_price = intval( round( $method->cost, 2 ) * 100 );
+					$method_price = intval( round( $method_cost, 2 ) * 100 );
 				} else {
-					$method_price = intval( round( $method->cost + array_sum( $method->taxes ), 2 ) * 100 );
+					$method_price = intval( round( $method_cost + array_sum( $method->taxes ), 2 ) * 100 );
 				}
 
 				if ( array_sum( $method->taxes ) > 0 && ( ! $separate_sales_tax ) ) {
 					$method_tax_amount = intval( round( array_sum( $method->taxes ), 2 ) * 100 );
-					$method_tax_rate   = intval( round( ( array_sum( $method->taxes ) / $method->cost ) * 100, 2 ) * 100 );
+					$method_tax_rate   = intval( round( ( array_sum( $method->taxes ) / $method_cost ) * 100, 2 ) * 100 );
 				} else {
 					$method_tax_amount = 0;
 					$method_tax_rate   = 0;


### PR DESCRIPTION
In the 9.9.x release, WC changed how they handle the price for local shipping (pickup) when the default placeholder value is used instead. When a value is not set, `"` is returned, which causes an "unsupported operand types" since we attempt to perform calculation on a non-numeric string.

- converts any costs that may return a string to float before performing calculation.

https://app.clickup.com/t/8699c8th1