### PR TITLE
Add numeric conversion helper

### DIFF
--- a/classes/requests/helpers/class-kco-request-shipping-options.php
+++ b/classes/requests/helpers/class-kco-request-shipping-options.php
@@ -31,6 +31,7 @@ class KCO_Request_Shipping_Options {
 			foreach ( $package['rates'] as $method ) {
 				$method_id   = $method->id;
 				$method_name = $method->label;
+				$method_cost = kco_ensure_numeric( $method->cost );
 
 				// Don't add the KSS shipping method as a shipping option. It should not be a valid fallback if it exists and the store uses a TMS system.
 				if ( false !== strpos( $method_id, 'klarna_kss' ) ) {
@@ -38,14 +39,14 @@ class KCO_Request_Shipping_Options {
 				}
 
 				if ( $separate_sales_tax ) {
-					$method_price = intval( round( $method->cost, 2 ) * 100 );
+					$method_price = intval( round( $method_cost, 2 ) * 100 );
 				} else {
-					$method_price = intval( round( $method->cost + array_sum( $method->taxes ), 2 ) * 100 );
+					$method_price = intval( round( $method_cost + array_sum( $method->taxes ), 2 ) * 100 );
 				}
 
 				if ( array_sum( $method->taxes ) > 0 && ( ! $separate_sales_tax ) ) {
 					$method_tax_amount = intval( round( array_sum( $method->taxes ), 2 ) * 100 );
-					$method_tax_rate   = intval( round( ( array_sum( $method->taxes ) / $method->cost ) * 100, 2 ) * 100 );
+					$method_tax_rate   = intval( round( ( array_sum( $method->taxes ) / $method_cost ) * 100, 2 ) * 100 );
 				} else {
 					$method_tax_amount = 0;
 					$method_tax_rate   = 0;

--- a/includes/kco-functions.php
+++ b/includes/kco-functions.php
@@ -968,3 +968,33 @@ function kco_is_bundle_plugin_installed() {
 
 	return false;
 }
+
+/**
+ * Ensure that a value is numeric. If the value is not numeric, it will attempt to convert it.
+ * If the value is an empty value, it will be set to 0.
+ * If the value cannot be converted to a numeric value, it will return the default value.
+ *
+ * @param mixed     $value The value to ensure is numeric.
+ * @param float|int $default The default value to return if the value is not numeric and $throw_error is false. Default 0.
+ *
+ * @return float|int Returns the numeric value of the input, or the default value if the input is not numeric and cannot be converted.
+ */
+function kco_ensure_numeric( $value, $default = 0 ) {
+	if ( is_numeric( $value ) ) {
+		return floatval( $value );
+	}
+
+	// If the value is empty, return 0 instead of default to reflect that the value is not set.
+	if ( empty( $value ) ) {
+		return 0;
+	}
+
+	// Try to convert the value to a numeric value.
+	$converted_value = floatval( $value );
+
+	if ( is_numeric( $converted_value ) ) {
+		return $converted_value;
+	}
+
+	return $default; // Return the default value if the value is still not numeric.
+}


### PR DESCRIPTION
Add a numeric conversion helper and implement for the shipping option price, to ensure a numeric value. Resolves potential for fatal error in checkout, in cases where shipping option price is returned as a string value.