### PR TITLE
Fix malformed kco_session_id

### DIFF
--- a/classes/requests/helpers/class-kco-merchant-urls.php
+++ b/classes/requests/helpers/class-kco-merchant-urls.php
@@ -175,14 +175,16 @@ class KCO_Merchant_URLs {
 	 * Get session ID.
 	 *
 	 * Gets WooCommerce session ID. Used to send in merchant url's to Klarn.
-	 * So we can retrieve the cart object in server to server calls from Kustom
+	 * So we can retrieve the cart object in server to server calls from Kustom.
 	 *
 	 * @return string
 	 */
 	private function get_session_id() {
 		foreach ( $_COOKIE as $key => $value ) {
 			if ( strpos( $key, 'wp_woocommerce_session_' ) !== false ) {
-				$session_id = explode( '||', $value );
+				// Prior to WooCommerce 10.0, the session data was `||`-separated. Now it is `|`-separated instead.
+				// Since we only need the first part of the session data, we can safely use `|` as a separator.
+				$session_id = explode( '|', $value );
 				return $session_id[0];
 			}
 		}

--- a/classes/requests/helpers/class-kco-merchant-urls.php
+++ b/classes/requests/helpers/class-kco-merchant-urls.php
@@ -101,11 +101,13 @@ class KCO_Merchant_URLs {
 	private function get_push_url() {
 		$session_id = $this->get_session_id();
 
-		$push_url = home_url(
-			sprintf(
-				'/wc-api/KCO_WC_Push/?kco-action=push&kco_wc_order_id={checkout.order.id}&kco_session_id=%s',
-				$session_id
-			)
+		$push_url = add_query_arg(
+			array(
+				'kco-action'      => 'push',
+				'kco_wc_order_id' => '{checkout.order.id}',
+				'kco_session_id'  => $session_id,
+			),
+			home_url( '/wc-api/KCO_WC_Push/' )
 		);
 
 		return apply_filters( 'kco_wc_push_url', $push_url );

--- a/classes/requests/helpers/class-kco-merchant-urls.php
+++ b/classes/requests/helpers/class-kco-merchant-urls.php
@@ -183,8 +183,13 @@ class KCO_Merchant_URLs {
 		foreach ( $_COOKIE as $key => $value ) {
 			if ( strpos( $key, 'wp_woocommerce_session_' ) !== false ) {
 				// Prior to WooCommerce 10.0, the session data was `||`-separated. Now it is `|`-separated instead.
-				// Since we only need the first part of the session data, we can safely use `|` as a separator.
-				$session_id = explode( '|', $value );
+				$session_id =
+				// Re-index to receive the same array structure as if it was separated by `||`.
+				array_values(
+				// Filter to remove the empty values that will occur due to splitting on `|`.
+					array_filter( explode( '|', $value ) )
+				);
+
 				return $session_id[0];
 			}
 		}


### PR DESCRIPTION
As of WC 10.0, the structure of the `wp_woocommerce_session_` cookie was changed to use a single pipe `|` to separate values instead of `||` like previously. This has resulted in split-by-delimiter to fail, yielding a session value that contain the entire content of the cookie instead of only the first index.

https://app.clickup.com/t/869a0dkx9