### PR TITLE
Fix kco_check_if_needs_payment

### DIFF
--- a/classes/class-kco-checkout.php
+++ b/classes/class-kco-checkout.php
@@ -233,6 +233,13 @@ class KCO_Checkout {
 		return true;
 	}
 
+	/**
+	 * Maybe change the needs payment status for the cart.
+	 *
+	 * @param bool    $needs_payment The current needs payment status.
+	 * @param WC_Cart $cart The WooCommerce cart.
+	 * @return bool
+	 */
 	public function maybe_change_needs_payment_cart( $needs_payment, $cart ) {
 
 		// Only if our filter is active and is set to false.


### PR DESCRIPTION
Make the `kco_check_if_needs_payment` filter work as intended again for free orders.

This makes the payment option appear in the checkout payment option list when using the filter (did not happen before this for me), and prevents the READ_ONLY_ORDER error from occurring in checkout.

My concern is that this potentially displays the other payment options as well; not sure how to solve this using this hook?