### PR TITLE
Allow processing free subscriptions

### DIFF
--- a/assets/js/klarna-checkout-for-woocommerce.js
+++ b/assets/js/klarna-checkout-for-woocommerce.js
@@ -540,11 +540,7 @@ jQuery( function ( $ ) {
 										email = response.data.shipping_address.email
 									}
 
-									kco_wc.logToFile(
-										"Successfully placed order [" +
-											email +
-											']. Sending "should_proceed: true" to Kustom',
-									)
+									kco_wc.logToFile( `Successfully placed order [${email}]. Sending "should_proceed: true" to Kustom` )
 									callback( { should_proceed: true } )
 								} else {
 									throw "Result failed"

--- a/classes/class-kco-api.php
+++ b/classes/class-kco-api.php
@@ -35,13 +35,11 @@ class KCO_API {
 	 *
 	 * @param string $session_id The Kustom Checkout session to use for the HPP request.
 	 * @param int    $order_id The WooCommerce order id to use for the HPP request.
-	 * @return mixed
+	 * @return array|WP_Error
 	 */
 	public function create_klarna_hpp_url( $session_id, $order_id ) {
-		$request  = new KCO_Request_Create_HPP();
-		$response = $request->request( $session_id, $order_id );
-
-		return $this->check_for_api_error( $response );
+		$request = new KCO_Request_Create_HPP();
+		return $request->request( $session_id, $order_id );
 	}
 
 	/**

--- a/classes/class-kco-subscription.php
+++ b/classes/class-kco-subscription.php
@@ -51,10 +51,23 @@ class KCO_Subscription {
 	 * @return bool
 	 */
 	public function allow_processing_free_subscription( $needs_payment ) {
-		$is_processing = did_action( 'woocommerce_checkout_order_processed' ) !== 0;
+		// Avoid additional checks if we already know that payment is needed.
+		if ( $needs_payment ) {
+			return $needs_payment;
+		}
+
+		// Only modify needs_payment when KCO is the chosen payment method.
+		$chosen_payment_method = WC()->session
+		? WC()->session->get( 'chosen_payment_method' )
+		: null;
+
+		if ( 'kco' !== $chosen_payment_method ) {
+			return $needs_payment;
+		}
 
 		// Avoid additional checks if we already know that payment is needed.
-		if ( $needs_payment || ! $is_processing ) {
+		$is_processing = did_action( 'woocommerce_checkout_order_processed' ) !== 0;
+		if ( ! $is_processing ) {
 			return $needs_payment;
 		}
 

--- a/classes/class-kco-subscription.php
+++ b/classes/class-kco-subscription.php
@@ -56,6 +56,16 @@ class KCO_Subscription {
 			return $needs_payment;
 		}
 
+		if ( ! self::cart_has_subscription() ) {
+			return $needs_payment;
+		}
+
+		// Ensure we only change needs_payment for WC is determining whether it should be processed with or without gateway payment.
+		$is_processing = did_action( 'woocommerce_checkout_order_processed' ) !== 0;
+		if ( ! $is_processing ) {
+			return $needs_payment;
+		}
+
 		// Only modify needs_payment when KCO is the chosen payment method.
 		$chosen_payment_method = WC()->session
 		? WC()->session->get( 'chosen_payment_method' )
@@ -65,13 +75,7 @@ class KCO_Subscription {
 			return $needs_payment;
 		}
 
-		// Avoid additional checks if we already know that payment is needed.
-		$is_processing = did_action( 'woocommerce_checkout_order_processed' ) !== 0;
-		if ( ! $is_processing ) {
-			return $needs_payment;
-		}
-
-		return self::cart_has_subscription() ? true : $needs_payment;
+		return true;
 	}
 
 	/**

--- a/classes/class-kco-subscription.php
+++ b/classes/class-kco-subscription.php
@@ -80,10 +80,6 @@ class KCO_Subscription {
 	 * @return bool
 	 */
 	public static function cart_has_subscription() {
-		if ( ! is_checkout() ) {
-			return false;
-		}
-
 		return ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) ||
 			( function_exists( 'wcs_cart_contains_renewal' ) && wcs_cart_contains_renewal() ) ||
 			( function_exists( 'wcs_cart_contains_failed_renewal_order_payment' ) && wcs_cart_contains_failed_renewal_order_payment() ) ||

--- a/classes/requests/checkout/post/class-kco-request-create-hpp.php
+++ b/classes/requests/checkout/post/class-kco-request-create-hpp.php
@@ -57,7 +57,7 @@ class KCO_Request_Create_HPP extends KCO_Request {
 	 *
 	 * @param string $session_id The Kustom Checkout session id.
 	 * @param int    $order_id The WooCommerce order id.
-	 * @return string
+	 * @return array
 	 */
 	public function get_body( $session_id, $order_id ) {
 		$order = wc_get_order( $order_id );

--- a/includes/kco-functions.php
+++ b/includes/kco-functions.php
@@ -831,7 +831,7 @@ function kco_maybe_save_surcharge( $order_id, $klarna_order ) {
 	if ( isset( $klarna_order['order_lines'] ) ) {
 		$order = wc_get_order( $order_id );
 		foreach ( $klarna_order['order_lines'] as $order_line ) {
-			if ( 'added-surcharge' === $order_line['reference'] ) {
+			if ( 'added-surcharge' === ( $order_line['reference'] ?? '' ) ) {
 				$order->update_meta_data( '_kco_added_surcharge', wp_json_encode( $order_line ) );
 			}
 		}

--- a/includes/kco-functions.php
+++ b/includes/kco-functions.php
@@ -914,7 +914,7 @@ function kco_update_wc_shipping( $data, $klarna_order = false ) {
 
 	set_transient( 'kss_data_' . $klarna_order_id, $data, HOUR_IN_SECONDS );
 	$chosen_shipping_methods   = array();
-	$chosen_shipping_methods[] = wc_clean( $data['id'] );
+	$chosen_shipping_methods[] = wc_clean( $data['id'] ?? '' );
 
 	KCO_Logger::Log( "Set chosen shipping method for $klarna_order_id " . wp_json_encode( $chosen_shipping_methods ) );
 

--- a/src/CheckoutFlow/CheckoutFlow.php
+++ b/src/CheckoutFlow/CheckoutFlow.php
@@ -18,20 +18,16 @@ abstract class CheckoutFlow {
 	 * @throws Exception If there is an error during the payment processing.
 	 */
 	public static function process_payment( $order_id ) {
-		try {
-			$order = wc_get_order( $order_id );
+		$order = wc_get_order( $order_id );
 
-			if ( ! $order ) {
-				throw new Exception( __( 'Invalid order ID.', 'klarna-checkout-for-woocommerce' ) );
-			}
-			$handler = self::get_handler();
-
-			\KCO_Logger::log( sprintf( 'Processing order %s|%s with flow %s.', $order->get_id(), $order->get_order_number(), get_class( $handler ) ) );
-
-			return $handler->process( $order );
-		} catch ( Exception $e ) {
-			return self::error_response( $e->getMessage() );
+		if ( ! $order ) {
+			throw new Exception( __( 'Invalid order ID.', 'klarna-checkout-for-woocommerce' ) );
 		}
+		$handler = self::get_handler();
+
+		\KCO_Logger::log( sprintf( 'Processing order %s|%s with flow %s.', $order->get_id(), $order->get_order_number(), get_class( $handler ) ) );
+
+		return $handler->process( $order );
 	}
 
 	/**

--- a/src/CheckoutFlow/CheckoutFlow.php
+++ b/src/CheckoutFlow/CheckoutFlow.php
@@ -21,7 +21,8 @@ abstract class CheckoutFlow {
 		$order = wc_get_order( $order_id );
 
 		if ( ! $order ) {
-			throw new Exception( __( 'Invalid order ID.', 'klarna-checkout-for-woocommerce' ) );
+			$message = __( 'Invalid order ID.', 'klarna-checkout-for-woocommerce' );
+			throw new Exception( esc_html( $message ) );
 		}
 		$handler = self::get_handler();
 

--- a/src/CheckoutFlow/RedirectFlow.php
+++ b/src/CheckoutFlow/RedirectFlow.php
@@ -27,8 +27,8 @@ class RedirectFlow extends CheckoutFlow {
 		$hpp = KCO_WC()->api->create_klarna_hpp_url( $klarna_order['order_id'], $order->get_id() );
 
 		if ( is_wp_error( $hpp ) ) {
-			\KCO_Logger::log( sprintf( 'Failed to create a HPP session with Kustom Order %s|%s (Kustom ID: %s) OK. Redirecting to hosted payment page.', $order->get_id(), $order->get_order_number(), $klarna_order['order_id'] ) );
-			throw new Exception( $hpp->get_error_message() );
+			\KCO_Logger::log( \sprintf( '[Process]: Failed to create a HPP session with Kustom Order %s|%s (Kustom ID: %s).', $order->get_id(), $order->get_order_number(), $klarna_order['order_id'] ) );
+			throw new Exception( __( "We couldn't start your payment session right now. Please try again in a moment or contact us if the issue continues.", 'klarna-checkout-for-woocommerce' ) );
 		}
 
 		$hpp_redirect = $hpp['redirect_url'];

--- a/src/CheckoutFlow/RedirectFlow.php
+++ b/src/CheckoutFlow/RedirectFlow.php
@@ -18,8 +18,8 @@ class RedirectFlow extends CheckoutFlow {
 	public function process( $order ) {
 		$klarna_order = KCO_WC()->api->create_klarna_order( $order->get_id(), 'redirect' );
 
-		if ( is_wp_error( $klarna_order ) ) {
-			throw new Exception( $klarna_order->get_error_message() );
+		if ( empty( $klarna_order ) ) {
+			throw new Exception( __( "We couldn't create your payment session right now. Please try again in a moment or contact us if the issue continues.", 'klarna-checkout-for-woocommerce' ) );
 		}
 
 		$this->save_order_metadata( $order, $klarna_order, 'redirect', false );

--- a/src/CheckoutFlow/RedirectFlow.php
+++ b/src/CheckoutFlow/RedirectFlow.php
@@ -19,7 +19,7 @@ class RedirectFlow extends CheckoutFlow {
 		$klarna_order = KCO_WC()->api->create_klarna_order( $order->get_id(), 'redirect' );
 
 		if ( is_wp_error( $klarna_order ) ) {
-			return $this->error_response( $klarna_order->get_error_message() );
+			throw new Exception( $klarna_order->get_error_message() );
 		}
 
 		$this->save_order_metadata( $order, $klarna_order, 'redirect', false );
@@ -28,7 +28,7 @@ class RedirectFlow extends CheckoutFlow {
 
 		if ( is_wp_error( $hpp ) ) {
 			\KCO_Logger::log( sprintf( 'Failed to create a HPP session with Kustom Order %s|%s (Kustom ID: %s) OK. Redirecting to hosted payment page.', $order->get_id(), $order->get_order_number(), $klarna_order['order_id'] ) );
-			return $this->error_response( $hpp->get_error_message() );
+			throw new Exception( $hpp->get_error_message() );
 		}
 
 		$hpp_redirect = $hpp['redirect_url'];

--- a/src/CheckoutFlow/RedirectFlow.php
+++ b/src/CheckoutFlow/RedirectFlow.php
@@ -19,7 +19,8 @@ class RedirectFlow extends CheckoutFlow {
 		$klarna_order = KCO_WC()->api->create_klarna_order( $order->get_id(), 'redirect' );
 
 		if ( empty( $klarna_order ) ) {
-			throw new Exception( __( "We couldn't create your payment session right now. Please try again in a moment or contact us if the issue continues.", 'klarna-checkout-for-woocommerce' ) );
+			$message = __( "We couldn't create your payment session right now. Please try again in a moment or contact us if the issue continues.", 'klarna-checkout-for-woocommerce' );
+			throw new Exception( esc_html( $message ) );
 		}
 
 		$this->save_order_metadata( $order, $klarna_order, 'redirect', false );
@@ -28,7 +29,8 @@ class RedirectFlow extends CheckoutFlow {
 
 		if ( is_wp_error( $hpp ) ) {
 			\KCO_Logger::log( \sprintf( '[Process]: Failed to create a HPP session with Kustom Order %s|%s (Kustom ID: %s).', $order->get_id(), $order->get_order_number(), $klarna_order['order_id'] ) );
-			throw new Exception( __( "We couldn't start your payment session right now. Please try again in a moment or contact us if the issue continues.", 'klarna-checkout-for-woocommerce' ) );
+			$message = __( "We couldn't start your payment session right now. Please try again in a moment or contact us if the issue continues.", 'klarna-checkout-for-woocommerce' );
+			throw new Exception( esc_html( $message ) );
 		}
 
 		$hpp_redirect = $hpp['redirect_url'];


### PR DESCRIPTION
The issue is that a, say, a virtual, non-trial free subscription product that doesn't need payment doesn't need payment processing. This results in our gateway never being called when the payment is processed.

I've forced `woocommerce_cart_needs_payment` to required payment if the cart contains any subscription, thus invoking our gateway processing. However, I suspect this is too general, and _may_ affect other gateways too that flag support for subscription. I am setting this as a draft while we explore our options, and consider this solution.

https://app.clickup.com/t/869c47ek6