### PR TITLE
Ensure post_id is checkoutpage before checking user permissions

### DIFF
--- a/src/Utility/BlocksUtility.php
+++ b/src/Utility/BlocksUtility.php
@@ -35,10 +35,14 @@ class BlocksUtility {
 			return false;
 		}
 
+		if ( wc_get_page_id( 'checkout' ) !== $post_id ) {
+			return false;
+		}
+
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			return false;
 		}
 
-		return $is_edit_context && wc_get_page_id( 'checkout' ) === $post_id;
+		return true;
 	}
 }


### PR DESCRIPTION
Krokedil\KustomCheckout\Utility\BlocksUtility::is_checkout_block_enabled() runs on plugins_loaded hook, at this time custom post types may not be registered. 
This causes _Notice: Function map_meta_cap was called incorrectly. The post type your_posttype is not registered_ notices when editing custom post types.

Since checkoutpage can only be a type page (at least i think) checking that the currently edited page is in fact the checkoutpage before running current_user_can check, and bailing if not, ensures current_user_can never runs on custom posttypes.