### PR TITLE
Settings page package integration updates

### DIFF
--- a/.changelogs/2026-04-01-improved-error-handling-settings-page
+++ b/.changelogs/2026-04-01-improved-error-handling-settings-page
@@ -1,0 +1,4 @@
+Type: Enhancement
+Needs Documentation: no
+
+Enhanced error handling for the settings page package, to prevent fatal errors and provide clearer feedback when errors occur.

--- a/.changelogs/2026-04-01-set-settings-args-in-plugin
+++ b/.changelogs/2026-04-01-set-settings-args-in-plugin
@@ -1,0 +1,4 @@
+Type: Tweak
+Needs Documentation: no
+
+Settings page design arguments are now defined directly within the plugin, rather than in the external configuration file.

--- a/classes/class-kco-gateway.php
+++ b/classes/class-kco-gateway.php
@@ -107,6 +107,9 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 
 			add_filter( 'kco_wc_api_request_args', array( $this, 'maybe_remove_kco_epm' ), 9999 );
 
+			// Log any errors from the settings page rendering, to be able to debug issues with the shared settings page package.
+			add_action( 'krokedil_settings_page_render_error', array( $this, 'log_settings_page_render_error' ), 10, 2 );
+
 			// Prevent the Woo validation from proceeding if there is a discrepancy between Woo and Kustom.
 			add_action( 'woocommerce_after_checkout_validation', array( $this, 'validate_checkout' ), 10, 2 );
 		}
@@ -290,34 +293,49 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 			$args = $this->get_settings_page_args();
 
 			if ( empty( $args ) ) {
-				ob_start();
-				parent::admin_options();
-				$parent_options = ob_get_contents();
-				ob_end_clean();
-				WC_Klarna_Banners::settings_sidebar( $parent_options );
+				$this->output_legacy_admin_options();
 			} else {
-				$args['icon']            = KCO_WC_PLUGIN_URL . '/assets/img/kustom_logo_black.png';
-				$gateway_page            = new Gateway( $this, $args );
-				$args['general_content'] = array( $gateway_page, 'output' );
+				$args['icon']             = KCO_WC_PLUGIN_URL . '/assets/img/kustom_logo_black.png';
+				$gateway_page             = new Gateway( $this, $args );
+				$args['general_content']  = array( $gateway_page, 'output' );
+				$args['fallback_content'] = array( $this, 'output_legacy_admin_options' );
+				$args['error_notice']     = __( 'Could not load the enhanced settings page. Showing the standard settings instead.', 'klarna-checkout-for-woocommerce' );
 
-				try {
-					( SettingsPage::get_instance() )
-						->set_plugin_name( 'Kustom Checkout for WooCommerce' )
-						->register_page( $this->id, $args, $this )
-						->output( $this->id );
-				} catch ( Throwable $e ) {
-					KCO_Logger::log( sprintf( 'Failed rendering settings page package output: %s', $e->getMessage() ) );
-					echo '<div class="notice notice-error"><p>' . esc_html__( 'Could not load the enhanced settings page. Showing the standard settings instead.', 'klarna-checkout-for-woocommerce' ) . '</p></div>';
-
-					ob_start();
-					parent::admin_options();
-					$parent_options = ob_get_contents();
-					ob_end_clean();
-					WC_Klarna_Banners::settings_sidebar( $parent_options );
-				}
+				( SettingsPage::get_instance() )
+					->set_plugin_name( 'Kustom Checkout for WooCommerce' )
+					->register_page( $this->id, $args, $this )
+					->output( $this->id );
 			}
 
 			KCO_Settings_Saved::maybe_show_errors();
+		}
+
+		/**
+		 * Output the standard WooCommerce admin options with the Kustom sidebar.
+		 *
+		 * @return void
+		 */
+		public function output_legacy_admin_options() {
+			ob_start();
+			parent::admin_options();
+			$parent_options = ob_get_contents();
+			ob_end_clean();
+			WC_Klarna_Banners::settings_sidebar( $parent_options );
+		}
+
+		/**
+		 * Log settings page rendering errors from the shared settings page package.
+		 *
+		 * @param string    $id Page ID.
+		 * @param Throwable $exception Render exception.
+		 * @return void
+		 */
+		public function log_settings_page_render_error( $id, $exception ) {
+			if ( ! $exception instanceof Throwable ) {
+				return;
+			}
+
+			KCO_Logger::log( sprintf( 'Failed rendering settings page package output: %s', $exception->getMessage() ) );
 		}
 
 		/**

--- a/classes/class-kco-gateway.php
+++ b/classes/class-kco-gateway.php
@@ -299,10 +299,22 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 				$args['icon']            = KCO_WC_PLUGIN_URL . '/assets/img/kustom_logo_black.png';
 				$gateway_page            = new Gateway( $this, $args );
 				$args['general_content'] = array( $gateway_page, 'output' );
-				$settings_page           = ( SettingsPage::get_instance() )
-				->set_plugin_name( 'Kustom Checkout for WooCommerce' )
-				->register_page( $this->id, $args, $this )
-				->output( $this->id );
+
+				try {
+					( SettingsPage::get_instance() )
+						->set_plugin_name( 'Kustom Checkout for WooCommerce' )
+						->register_page( $this->id, $args, $this )
+						->output( $this->id );
+				} catch ( Throwable $e ) {
+					KCO_Logger::log( sprintf( 'Failed rendering settings page package output: %s', $e->getMessage() ) );
+					echo '<div class="notice notice-error"><p>' . esc_html__( 'Could not load the enhanced settings page. Showing the standard settings instead.', 'klarna-checkout-for-woocommerce' ) . '</p></div>';
+
+					ob_start();
+					parent::admin_options();
+					$parent_options = ob_get_contents();
+					ob_end_clean();
+					WC_Klarna_Banners::settings_sidebar( $parent_options );
+				}
 			}
 
 			KCO_Settings_Saved::maybe_show_errors();

--- a/classes/class-kco-gateway.php
+++ b/classes/class-kco-gateway.php
@@ -780,7 +780,11 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 				set_transient( 'kustom_checkout_settings_page_config', $args, 60 * 60 * 24 ); // 24 hours lifetime.
 			}
 
-			return json_decode( $args, true );
+			$decoded_args                        = json_decode( $args, true );
+			$decoded_args['styled_output']       = true;
+			$decoded_args['settings_navigation'] = true;
+
+			return $decoded_args;
 		}
 
 		/**

--- a/composer-dependencies.lock
+++ b/composer-dependencies.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "krokedil/settings-page",
-            "version": "1.3.2",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/krokedil/settings-page.git",
-                "reference": "2d50b3b3d539d9418a3e2d699d3829e9a5c0566c"
+                "reference": "cb84eac94a7a4a2bee4eda5bc45fb9d22fa8af9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/krokedil/settings-page/zipball/2d50b3b3d539d9418a3e2d699d3829e9a5c0566c",
-                "reference": "2d50b3b3d539d9418a3e2d699d3829e9a5c0566c",
+                "url": "https://api.github.com/repos/krokedil/settings-page/zipball/cb84eac94a7a4a2bee4eda5bc45fb9d22fa8af9d",
+                "reference": "cb84eac94a7a4a2bee4eda5bc45fb9d22fa8af9d",
                 "shasum": ""
             },
             "require-dev": {
@@ -46,10 +46,10 @@
             ],
             "description": "A package to help setup settings pages in WordPress and WooCommerce for Krokedil plugins to add the Addons and Support tabs",
             "support": {
-                "source": "https://github.com/krokedil/settings-page/tree/1.3.2",
+                "source": "https://github.com/krokedil/settings-page/tree/1.3.3",
                 "issues": "https://github.com/krokedil/settings-page/issues"
             },
-            "time": "2026-01-23T10:41:25+00:00"
+            "time": "2026-04-16T09:10:47+00:00"
         },
         {
             "name": "krokedil/woocommerce",

--- a/composer.lock
+++ b/composer.lock
@@ -105,16 +105,16 @@
         },
         {
             "name": "php-stubs/woocommerce-stubs",
-            "version": "v10.6.1",
+            "version": "v10.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/woocommerce-stubs.git",
-                "reference": "ef96143054f60a2f0b2cfe8351f5d78448729e98"
+                "reference": "7251902ebc048626aff04855c333afa9f3bae2d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/ef96143054f60a2f0b2cfe8351f5d78448729e98",
-                "reference": "ef96143054f60a2f0b2cfe8351f5d78448729e98",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/7251902ebc048626aff04855c333afa9f3bae2d5",
+                "reference": "7251902ebc048626aff04855c333afa9f3bae2d5",
                 "shasum": ""
             },
             "require": {
@@ -143,9 +143,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
-                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v10.6.1"
+                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v10.7.0"
             },
-            "time": "2026-03-12T19:28:12+00:00"
+            "time": "2026-04-14T15:19:28+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",


### PR DESCRIPTION
* Sets the settings page styling arguments in the plugin instead of in the config file.

* Enhances the error handling for the settings page package by adding a try/catch with logging/and error message and a fallback to the default settings.