### PR TITLE
Redirect to confirmation flow if READ_ONLY but not paid

### DIFF
--- a/.changelogs/2026-04-01-redirect-confirmation
+++ b/.changelogs/2026-04-01-redirect-confirmation
@@ -1,4 +1,4 @@
 Type: Enhancement
 Needs Documentation: no
 
-If a Kustom order is detected as READ_ONLY while the customer is still on the checkout page, they will be manually redirected to the confirmation flow.
+If a Kustom order is detected as READ_ONLY while the customer is still on the checkout page, they will be redirected to the confirmation flow.

--- a/.changelogs/2026-04-01-redirect-confirmation
+++ b/.changelogs/2026-04-01-redirect-confirmation
@@ -1,0 +1,4 @@
+Type: Enhancement
+Needs Documentation: no
+
+If a Klarna order is detected as READ_ONLY while the customer is still on the checkout page, they will be manually redirected to the confirmation flow.

--- a/.changelogs/2026-04-01-redirect-confirmation
+++ b/.changelogs/2026-04-01-redirect-confirmation
@@ -1,4 +1,4 @@
 Type: Enhancement
 Needs Documentation: no
 
-If a Klarna order is detected as READ_ONLY while the customer is still on the checkout page, they will be manually redirected to the confirmation flow.
+If a Kustom order is detected as READ_ONLY while the customer is still on the checkout page, they will be manually redirected to the confirmation flow.

--- a/classes/class-kco-api.php
+++ b/classes/class-kco-api.php
@@ -86,7 +86,7 @@ class KCO_API {
 							array(
 								'kco_confirm'  => 'yes',
 								'kco_order_id' => $klarna_order_id,
-								'order_id'     => $order_id,
+								'order_id'     => $order->get_id(),
 								'key'          => $order->get_order_key(),
 							),
 							$order->get_checkout_order_received_url()

--- a/classes/class-kco-api.php
+++ b/classes/class-kco-api.php
@@ -73,13 +73,27 @@ class KCO_API {
 		if ( is_wp_error( $response ) ) {
 
 			// Data is returned as both json and string. Let's try to grab only the json data.
-			$extracted_response = strstr( $response->get_error_message(), '}', true ) . '}';
-			$extracted_response = json_decode( $extracted_response );
-			if ( is_object( $extracted_response ) && 'READ_ONLY_ORDER' === $extracted_response->error_code ?? false ) {
+			$error = strstr( $response->get_error_message(), '}', true ) . '}';
+			$error = json_decode( $error, true );
+			if ( is_array( $error ) && 'READ_ONLY_ORDER' === ( $error['error_code'] ?? false ) ) {
 				$order = kco_get_order_by_klarna_id( $klarna_order_id, '2 day ago' );
-
 				if ( ! empty( $order ) ) {
-					wp_safe_redirect( $order->get_checkout_order_received_url() );
+
+					$redirect_url = $order->get_checkout_order_received_url();
+					if ( empty( $order->get_date_paid() ) ) {
+						// If this was not paid directly, we're not dealing with a zero-order purchase (e.g., free trial subscription), and we should redirect to the confirmation page instead.
+						$redirect_url = add_query_arg(
+							array(
+								'kco_confirm'  => 'yes',
+								'kco_order_id' => $klarna_order_id,
+								'order_id'     => $order_id,
+								'key'          => $order->get_order_key(),
+							),
+							$order->get_checkout_order_received_url()
+						);
+					}
+
+					wp_safe_redirect( $redirect_url );
 					exit;
 				}
 			}


### PR DESCRIPTION
The `403 READ_ONLY_ORDER` is correctly interpreted as an indication that the purchase was already completed, however, the customer should be redirected to the confirmation flow, not directly to the order received page. 

https://app.clickup.com/t/869cpq4qu