### PR TITLE
Added 2nd paramter to http_headers_useragent

### DIFF
--- a/.changelogs/2026-04-12-missing-url-parameter-user-agent
+++ b/.changelogs/2026-04-12-missing-url-parameter-user-agent
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Added the request URL as the 2nd parameter to the 'http_headers_useragent' filter which is required for other plugins that hook onto this filter that need the URL to modify the user agent string accordingly.

--- a/classes/requests/checkout/get/class-kco-request-retrieve.php
+++ b/classes/requests/checkout/get/class-kco-request-retrieve.php
@@ -20,14 +20,14 @@ class KCO_Request_Retrieve extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $klarna_order_id ) {
-		$request_url       = $this->get_api_url_base() . 'checkout/v3/orders/' . $klarna_order_id;
+		$this->request_url = $this->get_api_url_base() . 'checkout/v3/orders/' . $klarna_order_id;
 		$request_args      = apply_filters( 'kco_wc_get_order', $this->get_request_args() );
-		$response          = wp_remote_request( $request_url, $request_args );
+		$response          = wp_remote_request( $this->request_url, $request_args );
 		$code              = wp_remote_retrieve_response_code( $response );
-		$formated_response = $this->process_response( $response, $request_args, $request_url );
+		$formated_response = $this->process_response( $response, $request_args, $this->request_url );
 
 		// Log the request.
-		$log = KCO_Logger::format_log( $klarna_order_id, 'GET', 'KCO get order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
+		$log = KCO_Logger::format_log( $klarna_order_id, 'GET', 'KCO get order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
 		KCO_Logger::log( $log );
 		return $formated_response;
 	}

--- a/classes/requests/checkout/get/class-kco-request-retrieve.php
+++ b/classes/requests/checkout/get/class-kco-request-retrieve.php
@@ -20,14 +20,14 @@ class KCO_Request_Retrieve extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $klarna_order_id ) {
-		$this->request_url = $this->get_api_url_base() . 'checkout/v3/orders/' . $klarna_order_id;
-		$request_args      = apply_filters( 'kco_wc_get_order', $this->get_request_args() );
-		$response          = wp_remote_request( $this->request_url, $request_args );
+		$request_url       = $this->get_api_url_base() . 'checkout/v3/orders/' . $klarna_order_id;
+		$request_args      = apply_filters( 'kco_wc_get_order', $this->get_request_args( $request_url ) );
+		$response          = wp_remote_request( $request_url, $request_args );
 		$code              = wp_remote_retrieve_response_code( $response );
-		$formated_response = $this->process_response( $response, $request_args, $this->request_url );
+		$formated_response = $this->process_response( $response, $request_args, $request_url );
 
 		// Log the request.
-		$log = KCO_Logger::format_log( $klarna_order_id, 'GET', 'KCO get order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
+		$log = KCO_Logger::format_log( $klarna_order_id, 'GET', 'KCO get order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
 		KCO_Logger::log( $log );
 		return $formated_response;
 	}
@@ -35,12 +35,13 @@ class KCO_Request_Retrieve extends KCO_Request {
 	/**
 	 * Gets the request args for the API call.
 	 *
+	 * @param string $url The request URL.
 	 * @return array
 	 */
-	protected function get_request_args() {
+	protected function get_request_args( $url = '' ) {
 		return array(
 			'headers'    => $this->get_request_headers(),
-			'user-agent' => $this->get_user_agent(),
+			'user-agent' => $this->get_user_agent( $url ),
 			'method'     => 'GET',
 			'timeout'    => apply_filters( 'kco_wc_request_timeout', 10 ),
 		);

--- a/classes/requests/checkout/post/class-kco-request-create-hpp.php
+++ b/classes/requests/checkout/post/class-kco-request-create-hpp.php
@@ -21,17 +21,17 @@ class KCO_Request_Create_HPP extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $session_id, $order_id ) {
-		$this->request_url = $this->get_api_url_base() . 'hpp/v1/sessions';
-		$request_args      = apply_filters( 'wc_klarna_checkout_create_hpp_args', $this->get_request_args( $session_id, $order_id ) );
+		$request_url  = $this->get_api_url_base() . 'hpp/v1/sessions';
+		$request_args = apply_filters( 'wc_klarna_checkout_create_hpp_args', $this->get_request_args( $session_id, $order_id, $request_url ) );
 
-		$response = wp_remote_request( $this->request_url, $request_args );
+		$response = wp_remote_request( $request_url, $request_args );
 		$code     = wp_remote_retrieve_response_code( $response );
 
 		// Log request.
-		$log = KCO_Logger::format_log( $session_id, 'POST', 'KCO create HPP', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
+		$log = KCO_Logger::format_log( $session_id, 'POST', 'KCO create HPP', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
 		KCO_Logger::log( $log );
 
-		$formated_response = $this->process_response( $response, $request_args, $this->request_url );
+		$formated_response = $this->process_response( $response, $request_args, $request_url );
 		return $formated_response;
 	}
 
@@ -40,12 +40,13 @@ class KCO_Request_Create_HPP extends KCO_Request {
 	 *
 	 * @param string $session_id The Kustom Payment session id.
 	 * @param int    $order_id The WooCommerce order id.
+	 * @param string $url The request URL.
 	 * @return array
 	 */
-	public function get_request_args( $session_id, $order_id ) {
+	public function get_request_args( $session_id, $order_id, $url = '' ) {
 		return array(
 			'headers'    => $this->get_request_headers(),
-			'user-agent' => $this->get_user_agent(),
+			'user-agent' => $this->get_user_agent( $url ),
 			'method'     => 'POST',
 			'body'       => wp_json_encode( apply_filters( 'kco_wc_api_hpp_request_args', $this->get_body( $session_id, $order_id ), $order_id, $session_id ) ),
 			'timeout'    => apply_filters( 'kco_wc_request_timeout', 10 ),

--- a/classes/requests/checkout/post/class-kco-request-create-hpp.php
+++ b/classes/requests/checkout/post/class-kco-request-create-hpp.php
@@ -21,17 +21,17 @@ class KCO_Request_Create_HPP extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $session_id, $order_id ) {
-		$request_url  = $this->get_api_url_base() . 'hpp/v1/sessions';
-		$request_args = apply_filters( 'wc_klarna_checkout_create_hpp_args', $this->get_request_args( $session_id, $order_id ) );
+		$this->request_url = $this->get_api_url_base() . 'hpp/v1/sessions';
+		$request_args      = apply_filters( 'wc_klarna_checkout_create_hpp_args', $this->get_request_args( $session_id, $order_id ) );
 
-		$response = wp_remote_request( $request_url, $request_args );
+		$response = wp_remote_request( $this->request_url, $request_args );
 		$code     = wp_remote_retrieve_response_code( $response );
 
 		// Log request.
-		$log = KCO_Logger::format_log( $session_id, 'POST', 'KCO create HPP', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
+		$log = KCO_Logger::format_log( $session_id, 'POST', 'KCO create HPP', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
 		KCO_Logger::log( $log );
 
-		$formated_response = $this->process_response( $response, $request_args, $request_url );
+		$formated_response = $this->process_response( $response, $request_args, $this->request_url );
 		return $formated_response;
 	}
 

--- a/classes/requests/checkout/post/class-kco-request-create-recurring.php
+++ b/classes/requests/checkout/post/class-kco-request-create-recurring.php
@@ -21,16 +21,16 @@ class KCO_Request_Create_Recurring extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $order_id = null, $recurring_token = null ) {
-		$this->request_url = $this->get_api_url_base() . 'customer-token/v1/tokens/' . $recurring_token . '/order';
-		$request_args      = apply_filters( 'kco_wc_create_recurring_order', $this->get_request_args( $order_id ) );
-		$response          = wp_remote_request( $this->request_url, $request_args );
+		$request_url       = $this->get_api_url_base() . 'customer-token/v1/tokens/' . $recurring_token . '/order';
+		$request_args      = apply_filters( 'kco_wc_create_recurring_order', $this->get_request_args( $order_id, $request_url ) );
+		$response          = wp_remote_request( $request_url, $request_args );
 		$code              = wp_remote_retrieve_response_code( $response );
-		$formated_response = $this->process_response( $response, $request_args, $this->request_url );
+		$formated_response = $this->process_response( $response, $request_args, $request_url );
 
 		$klarna_order_id = is_wp_error( $formated_response ) ? null : $formated_response['order_id'];
 
 		// Log the request.
-		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO create recurring order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
+		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO create recurring order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
 		KCO_Logger::log( $log );
 		return $formated_response;
 	}
@@ -60,13 +60,14 @@ class KCO_Request_Create_Recurring extends KCO_Request {
 	/**
 	 * Gets the request args for the API call.
 	 *
-	 * @param int $order_id The WooCommerce order id.
+	 * @param int    $order_id The WooCommerce order id.
+	 * @param string $url The request URL.
 	 * @return array
 	 */
-	protected function get_request_args( $order_id ) {
+	protected function get_request_args( $order_id, $url = '' ) {
 		return array(
 			'headers'    => $this->get_request_headers(),
-			'user-agent' => $this->get_user_agent(),
+			'user-agent' => $this->get_user_agent( $url ),
 			'method'     => 'POST',
 			'body'       => wp_json_encode( $this->get_body( $order_id ) ),
 			'timeout'    => apply_filters( 'kco_wc_request_timeout', 10 ),

--- a/classes/requests/checkout/post/class-kco-request-create-recurring.php
+++ b/classes/requests/checkout/post/class-kco-request-create-recurring.php
@@ -21,16 +21,16 @@ class KCO_Request_Create_Recurring extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $order_id = null, $recurring_token = null ) {
-		$request_url       = $this->get_api_url_base() . 'customer-token/v1/tokens/' . $recurring_token . '/order';
+		$this->request_url = $this->get_api_url_base() . 'customer-token/v1/tokens/' . $recurring_token . '/order';
 		$request_args      = apply_filters( 'kco_wc_create_recurring_order', $this->get_request_args( $order_id ) );
-		$response          = wp_remote_request( $request_url, $request_args );
+		$response          = wp_remote_request( $this->request_url, $request_args );
 		$code              = wp_remote_retrieve_response_code( $response );
-		$formated_response = $this->process_response( $response, $request_args, $request_url );
+		$formated_response = $this->process_response( $response, $request_args, $this->request_url );
 
 		$klarna_order_id = is_wp_error( $formated_response ) ? null : $formated_response['order_id'];
 
 		// Log the request.
-		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO create recurring order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
+		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO create recurring order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
 		KCO_Logger::log( $log );
 		return $formated_response;
 	}

--- a/classes/requests/checkout/post/class-kco-request-create.php
+++ b/classes/requests/checkout/post/class-kco-request-create.php
@@ -14,6 +14,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class KCO_Request_Create extends KCO_Request {
 	/**
+	 * The API endpoint for creating orders.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = 'checkout/v3/orders';
+
+	/**
 	 * Makes the request.
 	 *
 	 * @param int    $order_id The WooCommerce order id.
@@ -21,16 +28,16 @@ class KCO_Request_Create extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $order_id = null, $checkout_flow = 'embedded' ) {
-		$this->request_url = $this->get_api_url_base() . $this->endpoint;
-		$request_args      = apply_filters( 'kco_wc_create_order', $this->get_request_args( $order_id, $checkout_flow ) );
-		$response          = wp_remote_request( $this->request_url, $request_args );
+		$request_url       = $this->get_api_url_base() . $this->endpoint;
+		$request_args      = apply_filters( 'kco_wc_create_order', $this->get_request_args( $order_id, $checkout_flow, $request_url ) );
+		$response          = wp_remote_request( $request_url, $request_args );
 		$code              = wp_remote_retrieve_response_code( $response );
-		$formated_response = $this->process_response( $response, $request_args, $this->request_url );
+		$formated_response = $this->process_response( $response, $request_args, $request_url );
 
 		$klarna_order_id = is_wp_error( $formated_response ) ? null : $formated_response['order_id'];
 
 		// Log the request.
-		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO create order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
+		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO create order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
 		KCO_Logger::log( $log );
 		return $formated_response;
 	}
@@ -365,12 +372,13 @@ class KCO_Request_Create extends KCO_Request {
 	 *
 	 * @param int    $order_id The WooCommerce order id.
 	 * @param string $checkout_flow Embedded in checkout page or redirect via Kustom HPP.
+	 * @param string $url The request URL.
 	 * @return array
 	 */
-	protected function get_request_args( $order_id, $checkout_flow ) {
+	protected function get_request_args( $order_id, $checkout_flow, $url = '' ) {
 		return array(
 			'headers'    => $this->get_request_headers(),
-			'user-agent' => $this->get_user_agent(),
+			'user-agent' => $this->get_user_agent( $url ),
 			'method'     => 'POST',
 			'body'       => wp_json_encode( apply_filters( 'kco_wc_api_request_args', $this->get_body( $order_id, $checkout_flow ), $order_id ) ),
 			'timeout'    => apply_filters( 'kco_wc_request_timeout', 10 ),

--- a/classes/requests/checkout/post/class-kco-request-create.php
+++ b/classes/requests/checkout/post/class-kco-request-create.php
@@ -13,12 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Create KCO Order
  */
 class KCO_Request_Create extends KCO_Request {
-	/**
-	 * The API endpoint for creating orders.
-	 *
-	 * @var string
-	 */
-	protected $endpoint = 'checkout/v3/orders';
 
 	/**
 	 * Makes the request.
@@ -28,7 +22,7 @@ class KCO_Request_Create extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $order_id = null, $checkout_flow = 'embedded' ) {
-		$request_url       = $this->get_api_url_base() . $this->endpoint;
+		$request_url       = $this->get_api_url_base() . 'checkout/v3/orders';
 		$request_args      = apply_filters( 'kco_wc_create_order', $this->get_request_args( $order_id, $checkout_flow, $request_url ) );
 		$response          = wp_remote_request( $request_url, $request_args );
 		$code              = wp_remote_retrieve_response_code( $response );

--- a/classes/requests/checkout/post/class-kco-request-create.php
+++ b/classes/requests/checkout/post/class-kco-request-create.php
@@ -21,16 +21,16 @@ class KCO_Request_Create extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $order_id = null, $checkout_flow = 'embedded' ) {
-		$request_url       = $this->get_api_url_base() . 'checkout/v3/orders';
+		$this->request_url = $this->get_api_url_base() . $this->endpoint;
 		$request_args      = apply_filters( 'kco_wc_create_order', $this->get_request_args( $order_id, $checkout_flow ) );
-		$response          = wp_remote_request( $request_url, $request_args );
+		$response          = wp_remote_request( $this->request_url, $request_args );
 		$code              = wp_remote_retrieve_response_code( $response );
-		$formated_response = $this->process_response( $response, $request_args, $request_url );
+		$formated_response = $this->process_response( $response, $request_args, $this->request_url );
 
 		$klarna_order_id = is_wp_error( $formated_response ) ? null : $formated_response['order_id'];
 
 		// Log the request.
-		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO create order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
+		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO create order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
 		KCO_Logger::log( $log );
 		return $formated_response;
 	}

--- a/classes/requests/checkout/post/class-kco-request-test-credentials.php
+++ b/classes/requests/checkout/post/class-kco-request-test-credentials.php
@@ -23,14 +23,14 @@ class KCO_Request_Test_Credentials extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $username, $password, $testmode, $endpoint ) {
-		$request_url        = $this->get_test_endpoint( $testmode, $endpoint, $username, $password ) . 'checkout/v3/orders';
+		$this->request_url  = $this->get_test_endpoint( $testmode, $endpoint, $username, $password ) . 'checkout/v3/orders';
 		$request_args       = apply_filters( 'kco_wc_test_credentials', $this->get_request_args( $username, $password ) );
-		$response           = wp_remote_request( $request_url, $request_args );
+		$response           = wp_remote_request( $this->request_url, $request_args );
 		$code               = wp_remote_retrieve_response_code( $response );
-		$formatted_response = $this->process_response( $response, $request_args, $request_url );
+		$formatted_response = $this->process_response( $response, $request_args, $this->request_url );
 
 		// Log the request.
-		$log = KCO_Logger::format_log( null, 'POST', 'KCO test credentials', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
+		$log = KCO_Logger::format_log( null, 'POST', 'KCO test credentials', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
 		KCO_Logger::log( $log );
 		return $formatted_response;
 	}

--- a/classes/requests/checkout/post/class-kco-request-test-credentials.php
+++ b/classes/requests/checkout/post/class-kco-request-test-credentials.php
@@ -23,14 +23,14 @@ class KCO_Request_Test_Credentials extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $username, $password, $testmode, $endpoint ) {
-		$this->request_url  = $this->get_test_endpoint( $testmode, $endpoint, $username, $password ) . 'checkout/v3/orders';
-		$request_args       = apply_filters( 'kco_wc_test_credentials', $this->get_request_args( $username, $password ) );
-		$response           = wp_remote_request( $this->request_url, $request_args );
+		$request_url        = $this->get_test_endpoint( $testmode, $endpoint, $username, $password ) . 'checkout/v3/orders';
+		$request_args       = apply_filters( 'kco_wc_test_credentials', $this->get_request_args( $username, $password, $request_url ) );
+		$response           = wp_remote_request( $request_url, $request_args );
 		$code               = wp_remote_retrieve_response_code( $response );
-		$formatted_response = $this->process_response( $response, $request_args, $this->request_url );
+		$formatted_response = $this->process_response( $response, $request_args, $request_url );
 
 		// Log the request.
-		$log = KCO_Logger::format_log( null, 'POST', 'KCO test credentials', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
+		$log = KCO_Logger::format_log( null, 'POST', 'KCO test credentials', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
 		KCO_Logger::log( $log );
 		return $formatted_response;
 	}
@@ -68,16 +68,17 @@ class KCO_Request_Test_Credentials extends KCO_Request {
 	 *
 	 * @param string $username The username to use.
 	 * @param string $password The password to use.
+	 * @param string $url The request URL.
 	 * @return array
 	 */
-	protected function get_request_args( $username, $password ) {
+	protected function get_request_args( $username, $password, $url = '' ) {
 			return array(
 				'headers'    => array(
 					'Authorization'  => 'Basic ' . base64_encode( $username . ':' . $password ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions -- Base64 used to calculate auth header.
 					'Content-Type'   => 'application/json',
 					'kustom-partner' => 'PG000651',
 				),
-				'user-agent' => $this->get_user_agent(),
+				'user-agent' => $this->get_user_agent( $url ),
 				'method'     => 'POST',
 				'body'       => wp_json_encode( $this->get_body() ),
 				'timeout'    => apply_filters( 'kco_wc_request_timeout', 10 ),

--- a/classes/requests/checkout/post/class-kco-request-update-confirmation.php
+++ b/classes/requests/checkout/post/class-kco-request-update-confirmation.php
@@ -22,14 +22,14 @@ class KCO_Request_Update_Confirmation extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $klarna_order_id, $klarna_order, $order_id ) {
-		$this->request_url = $this->get_api_url_base() . 'checkout/v3/orders/' . $klarna_order_id;
-		$request_args      = apply_filters( 'kco_wc_update_order', $this->get_request_args( $klarna_order, $order_id ) );
-		$response          = wp_remote_request( $this->request_url, $request_args );
+		$request_url       = $this->get_api_url_base() . 'checkout/v3/orders/' . $klarna_order_id;
+		$request_args      = apply_filters( 'kco_wc_update_order', $this->get_request_args( $klarna_order, $order_id, $request_url ) );
+		$response          = wp_remote_request( $request_url, $request_args );
 		$code              = wp_remote_retrieve_response_code( $response );
-		$formated_response = $this->process_response( $response, $request_args, $this->request_url );
+		$formated_response = $this->process_response( $response, $request_args, $request_url );
 
 		// Log the request.
-		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO update confirmation', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
+		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO update confirmation', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
 		KCO_Logger::log( $log );
 		return $formated_response;
 	}
@@ -75,12 +75,13 @@ class KCO_Request_Update_Confirmation extends KCO_Request {
 	 *
 	 * @param array  $klarna_order The Kustom order to be modified.
 	 * @param string $order_id The WooCommerce order id.
+	 * @param string $url The request URL.
 	 * @return array
 	 */
-	protected function get_request_args( $klarna_order, $order_id ) {
+	protected function get_request_args( $klarna_order, $order_id, $url = '' ) {
 		return array(
 			'headers'    => $this->get_request_headers(),
-			'user-agent' => $this->get_user_agent(),
+			'user-agent' => $this->get_user_agent( $url ),
 			'method'     => 'POST',
 			'body'       => wp_json_encode( apply_filters( 'kco_wc_api_request_args', $this->get_body( $klarna_order, $order_id ), $order_id ) ),
 			'timeout'    => apply_filters( 'kco_wc_request_timeout', 10 ),

--- a/classes/requests/checkout/post/class-kco-request-update-confirmation.php
+++ b/classes/requests/checkout/post/class-kco-request-update-confirmation.php
@@ -22,14 +22,14 @@ class KCO_Request_Update_Confirmation extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $klarna_order_id, $klarna_order, $order_id ) {
-		$request_url       = $this->get_api_url_base() . 'checkout/v3/orders/' . $klarna_order_id;
+		$this->request_url = $this->get_api_url_base() . 'checkout/v3/orders/' . $klarna_order_id;
 		$request_args      = apply_filters( 'kco_wc_update_order', $this->get_request_args( $klarna_order, $order_id ) );
-		$response          = wp_remote_request( $request_url, $request_args );
+		$response          = wp_remote_request( $this->request_url, $request_args );
 		$code              = wp_remote_retrieve_response_code( $response );
-		$formated_response = $this->process_response( $response, $request_args, $request_url );
+		$formated_response = $this->process_response( $response, $request_args, $this->request_url );
 
 		// Log the request.
-		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO update confirmation', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
+		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO update confirmation', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
 		KCO_Logger::log( $log );
 		return $formated_response;
 	}

--- a/classes/requests/checkout/post/class-kco-request-update.php
+++ b/classes/requests/checkout/post/class-kco-request-update.php
@@ -22,8 +22,8 @@ class KCO_Request_Update extends KCO_Request {
 	 * @return array|false|WP_Error
 	 */
 	public function request( $klarna_order_id, $order_id = null, $force = false ) {
-		$request_url  = $this->get_api_url_base() . 'checkout/v3/orders/' . $klarna_order_id;
-		$request_args = apply_filters( 'kco_wc_update_order', $this->get_request_args( $order_id ) );
+		$this->request_url = $this->get_api_url_base() . 'checkout/v3/orders/' . $klarna_order_id;
+		$request_args      = apply_filters( 'kco_wc_update_order', $this->get_request_args( $order_id ) );
 
 		// Check if we need to update.
 		if ( WC()->session->get( 'kco_update_md5' ) && WC()->session->get( 'kco_update_md5' ) === md5( wp_json_encode( $request_args ) ) && ! $force ) {
@@ -31,12 +31,12 @@ class KCO_Request_Update extends KCO_Request {
 		}
 		WC()->session->set( 'kco_update_md5', md5( wp_json_encode( $request_args ) ) );
 
-		$response           = wp_remote_request( $request_url, $request_args );
+		$response           = wp_remote_request( $this->request_url, $request_args );
 		$code               = wp_remote_retrieve_response_code( $response );
-		$formatted_response = $this->process_response( $response, $request_args, $request_url );
+		$formatted_response = $this->process_response( $response, $request_args, $this->request_url );
 
 		// Log the request.
-		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO update order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
+		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO update order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
 		KCO_Logger::log( $log );
 		return $formatted_response;
 	}

--- a/classes/requests/checkout/post/class-kco-request-update.php
+++ b/classes/requests/checkout/post/class-kco-request-update.php
@@ -22,8 +22,8 @@ class KCO_Request_Update extends KCO_Request {
 	 * @return array|false|WP_Error
 	 */
 	public function request( $klarna_order_id, $order_id = null, $force = false ) {
-		$this->request_url = $this->get_api_url_base() . 'checkout/v3/orders/' . $klarna_order_id;
-		$request_args      = apply_filters( 'kco_wc_update_order', $this->get_request_args( $order_id ) );
+		$request_url  = $this->get_api_url_base() . 'checkout/v3/orders/' . $klarna_order_id;
+		$request_args = apply_filters( 'kco_wc_update_order', $this->get_request_args( $order_id, $request_url ) );
 
 		// Check if we need to update.
 		if ( WC()->session->get( 'kco_update_md5' ) && WC()->session->get( 'kco_update_md5' ) === md5( wp_json_encode( $request_args ) ) && ! $force ) {
@@ -31,12 +31,12 @@ class KCO_Request_Update extends KCO_Request {
 		}
 		WC()->session->set( 'kco_update_md5', md5( wp_json_encode( $request_args ) ) );
 
-		$response           = wp_remote_request( $this->request_url, $request_args );
+		$response           = wp_remote_request( $request_url, $request_args );
 		$code               = wp_remote_retrieve_response_code( $response );
-		$formatted_response = $this->process_response( $response, $request_args, $this->request_url );
+		$formatted_response = $this->process_response( $response, $request_args, $request_url );
 
 		// Log the request.
-		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO update order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
+		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO update order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
 		KCO_Logger::log( $log );
 		return $formatted_response;
 	}
@@ -119,12 +119,13 @@ class KCO_Request_Update extends KCO_Request {
 	 * Gets the request args for the API call.
 	 *
 	 * @param string $order_id The WooCommerce order id.
+	 * @param string $url The request URL.
 	 * @return array
 	 */
-	protected function get_request_args( $order_id ) {
+	protected function get_request_args( $order_id, $url = '' ) {
 		return array(
 			'headers'    => $this->get_request_headers(),
-			'user-agent' => $this->get_user_agent(),
+			'user-agent' => $this->get_user_agent( $url ),
 			'method'     => 'POST',
 			'body'       => wp_json_encode( apply_filters( 'kco_wc_api_request_args', $this->get_body( $order_id ), $order_id ) ),
 			'timeout'    => apply_filters( 'kco_wc_request_timeout', 10 ),

--- a/classes/requests/class-kco-request.php
+++ b/classes/requests/class-kco-request.php
@@ -40,13 +40,6 @@ class KCO_Request {
 	protected $endpoint;
 
 	/**
-	 * The request URL for the current request.
-	 *
-	 * @var string
-	 */
-	protected $request_url = '';
-
-	/**
 	 * Class constructor.
 	 */
 	public function __construct() {
@@ -111,13 +104,14 @@ class KCO_Request {
 	/**
 	 * Gets Kustom API request headers.
 	 *
+	 * @param string $url The request URL.
 	 * @return string
 	 */
-	protected function get_user_agent() {
+	protected function get_user_agent( $url = '' ) {
 		return apply_filters(
 			'http_headers_useragent',
 			'WordPress/' . get_bloginfo( 'version' ) . '; ' . get_bloginfo( 'url' ),
-			empty( $this->request_url ) ? $this->get_api_url_base() : $this->request_url
+			empty( $url ) ? $this->get_api_url_base() : $url
 		) . ' - WooCommerce: ' . WC()->version . ' - KCO:' . KCO_WC_VERSION . ' - PHP Version: ' . phpversion() . ' - Krokedil';
 	}
 

--- a/classes/requests/class-kco-request.php
+++ b/classes/requests/class-kco-request.php
@@ -37,6 +37,15 @@ class KCO_Request {
 	 */
 	protected $shop_country;
 
+	protected $endpoint;
+
+	/**
+	 * The request URL for the current request.
+	 *
+	 * @var string
+	 */
+	protected $request_url = '';
+
 	/**
 	 * Class constructor.
 	 */
@@ -107,7 +116,8 @@ class KCO_Request {
 	protected function get_user_agent() {
 		return apply_filters(
 			'http_headers_useragent',
-			'WordPress/' . get_bloginfo( 'version' ) . '; ' . get_bloginfo( 'url' )
+			'WordPress/' . get_bloginfo( 'version' ) . '; ' . get_bloginfo( 'url' ),
+			empty( $this->request_url ) ? $this->get_api_url_base() : $this->request_url
 		) . ' - WooCommerce: ' . WC()->version . ' - KCO:' . KCO_WC_VERSION . ' - PHP Version: ' . phpversion() . ' - Krokedil';
 	}
 

--- a/classes/requests/class-kco-request.php
+++ b/classes/requests/class-kco-request.php
@@ -102,7 +102,7 @@ class KCO_Request {
 	}
 
 	/**
-	 * Gets Kustom API request headers.
+	 * Gets the user agent for the API call.
 	 *
 	 * @param string $url The request URL.
 	 * @return string

--- a/classes/requests/class-kco-request.php
+++ b/classes/requests/class-kco-request.php
@@ -37,8 +37,6 @@ class KCO_Request {
 	 */
 	protected $shop_country;
 
-	protected $endpoint;
-
 	/**
 	 * Class constructor.
 	 */

--- a/classes/requests/order-management/get/class-kco-request-get-order.php
+++ b/classes/requests/order-management/get/class-kco-request-get-order.php
@@ -20,14 +20,14 @@ class KCO_Request_Get_Order extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $klarna_order_id ) {
-		$request_url       = $this->get_api_url_base() . 'ordermanagement/v1/orders/' . $klarna_order_id;
+		$this->request_url = $this->get_api_url_base() . 'ordermanagement/v1/orders/' . $klarna_order_id;
 		$request_args      = apply_filters( 'kco_wc_get_order', $this->get_request_args() );
-		$response          = wp_remote_request( $request_url, $request_args );
+		$response          = wp_remote_request( $this->request_url, $request_args );
 		$code              = wp_remote_retrieve_response_code( $response );
-		$formated_response = $this->process_response( $response, $request_args, $request_url );
+		$formated_response = $this->process_response( $response, $request_args, $this->request_url );
 
 		// Log the request.
-		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO get order management order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
+		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO get order management order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
 		KCO_Logger::log( $log );
 		return $formated_response;
 	}

--- a/classes/requests/order-management/get/class-kco-request-get-order.php
+++ b/classes/requests/order-management/get/class-kco-request-get-order.php
@@ -20,14 +20,14 @@ class KCO_Request_Get_Order extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $klarna_order_id ) {
-		$this->request_url = $this->get_api_url_base() . 'ordermanagement/v1/orders/' . $klarna_order_id;
-		$request_args      = apply_filters( 'kco_wc_get_order', $this->get_request_args() );
-		$response          = wp_remote_request( $this->request_url, $request_args );
+		$request_url       = $this->get_api_url_base() . 'ordermanagement/v1/orders/' . $klarna_order_id;
+		$request_args      = apply_filters( 'kco_wc_get_order', $this->get_request_args( $request_url ) );
+		$response          = wp_remote_request( $request_url, $request_args );
 		$code              = wp_remote_retrieve_response_code( $response );
-		$formated_response = $this->process_response( $response, $request_args, $this->request_url );
+		$formated_response = $this->process_response( $response, $request_args, $request_url );
 
 		// Log the request.
-		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO get order management order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
+		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO get order management order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
 		KCO_Logger::log( $log );
 		return $formated_response;
 	}
@@ -35,12 +35,13 @@ class KCO_Request_Get_Order extends KCO_Request {
 	/**
 	 * Gets the request args for the API call.
 	 *
+	 * @param string $url The request URL.
 	 * @return array
 	 */
-	protected function get_request_args() {
+	protected function get_request_args( $url = '' ) {
 		return array(
 			'headers'    => $this->get_request_headers(),
-			'user-agent' => $this->get_user_agent(),
+			'user-agent' => $this->get_user_agent( $url ),
 			'method'     => 'GET',
 			'timeout'    => apply_filters( 'kco_wc_request_timeout', 10 ),
 		);

--- a/classes/requests/order-management/patch/class-kco-request-set-merchant-reference.php
+++ b/classes/requests/order-management/patch/class-kco-request-set-merchant-reference.php
@@ -21,14 +21,14 @@ class KCO_Request_Set_Merchant_Reference extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $klarna_order_id, $order_id ) {
-		$this->request_url = $this->get_api_url_base() . 'ordermanagement/v1/orders/' . $klarna_order_id . '/merchant-references';
-		$request_args      = apply_filters( 'kco_wc_acknowledge_order', $this->get_request_args( $order_id ) );
-		$response          = wp_remote_request( $this->request_url, $request_args );
+		$request_url       = $this->get_api_url_base() . 'ordermanagement/v1/orders/' . $klarna_order_id . '/merchant-references';
+		$request_args      = apply_filters( 'kco_wc_acknowledge_order', $this->get_request_args( $order_id, $request_url ) );
+		$response          = wp_remote_request( $request_url, $request_args );
 		$code              = wp_remote_retrieve_response_code( $response );
-		$formated_response = $this->process_response( $response, $request_args, $this->request_url );
+		$formated_response = $this->process_response( $response, $request_args, $request_url );
 
 		// Log the request.
-		$log = KCO_Logger::format_log( $klarna_order_id, 'PATCH', 'KCO set merchant reference', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
+		$log = KCO_Logger::format_log( $klarna_order_id, 'PATCH', 'KCO set merchant reference', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
 		KCO_Logger::log( $log );
 		return $formated_response;
 	}
@@ -50,13 +50,14 @@ class KCO_Request_Set_Merchant_Reference extends KCO_Request {
 	/**
 	 * Gets the request args for the API call.
 	 *
-	 * @param int $order_id The WooCommerce order id.
+	 * @param int    $order_id The WooCommerce order id.
+	 * @param string $url The request URL.
 	 * @return array
 	 */
-	protected function get_request_args( $order_id ) {
+	protected function get_request_args( $order_id, $url = '' ) {
 		return array(
 			'headers'    => $this->get_request_headers(),
-			'user-agent' => $this->get_user_agent(),
+			'user-agent' => $this->get_user_agent( $url ),
 			'method'     => 'PATCH',
 			'body'       => wp_json_encode( $this->get_body( $order_id ) ),
 			'timeout'    => apply_filters( 'kco_wc_request_timeout', 10 ),

--- a/classes/requests/order-management/patch/class-kco-request-set-merchant-reference.php
+++ b/classes/requests/order-management/patch/class-kco-request-set-merchant-reference.php
@@ -21,14 +21,14 @@ class KCO_Request_Set_Merchant_Reference extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $klarna_order_id, $order_id ) {
-		$request_url       = $this->get_api_url_base() . 'ordermanagement/v1/orders/' . $klarna_order_id . '/merchant-references';
+		$this->request_url = $this->get_api_url_base() . 'ordermanagement/v1/orders/' . $klarna_order_id . '/merchant-references';
 		$request_args      = apply_filters( 'kco_wc_acknowledge_order', $this->get_request_args( $order_id ) );
-		$response          = wp_remote_request( $request_url, $request_args );
+		$response          = wp_remote_request( $this->request_url, $request_args );
 		$code              = wp_remote_retrieve_response_code( $response );
-		$formated_response = $this->process_response( $response, $request_args, $request_url );
+		$formated_response = $this->process_response( $response, $request_args, $this->request_url );
 
 		// Log the request.
-		$log = KCO_Logger::format_log( $klarna_order_id, 'PATCH', 'KCO set merchant reference', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
+		$log = KCO_Logger::format_log( $klarna_order_id, 'PATCH', 'KCO set merchant reference', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
 		KCO_Logger::log( $log );
 		return $formated_response;
 	}

--- a/classes/requests/order-management/patch/class-kco-request-upsell-order.php
+++ b/classes/requests/order-management/patch/class-kco-request-upsell-order.php
@@ -22,18 +22,18 @@ class KCO_Request_Upsell_Order extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $klarna_order_id, $order_id, $upsell_uuid ) {
-		$request_url  = $this->get_api_url_base() . 'ordermanagement/v1/orders/' . $klarna_order_id . '/authorization';
-		$request_args = apply_filters( 'kco_wc_acknowledge_order', $this->get_request_args( $order_id, $upsell_uuid ) );
+		$this->request_url = $this->get_api_url_base() . 'ordermanagement/v1/orders/' . $klarna_order_id . '/authorization';
+		$request_args      = apply_filters( 'kco_wc_acknowledge_order', $this->get_request_args( $order_id, $upsell_uuid ) );
 
 		$body_array           = apply_filters( 'kco_wc_api_request_args', json_decode( $request_args['body'], true ), $order_id, $upsell_uuid );
 		$request_args['body'] = wp_json_encode( $body_array );
 
-		$response          = wp_remote_request( $request_url, $request_args );
+		$response          = wp_remote_request( $this->request_url, $request_args );
 		$code              = wp_remote_retrieve_response_code( $response );
-		$formated_response = $this->process_response( $response, $request_args, $request_url );
+		$formated_response = $this->process_response( $response, $request_args, $this->request_url );
 
 		// Log the request.
-		$log = KCO_Logger::format_log( $klarna_order_id, 'PATCH', 'KCO upsell order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
+		$log = KCO_Logger::format_log( $klarna_order_id, 'PATCH', 'KCO upsell order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
 		KCO_Logger::log( $log );
 		return $formated_response;
 	}

--- a/classes/requests/order-management/patch/class-kco-request-upsell-order.php
+++ b/classes/requests/order-management/patch/class-kco-request-upsell-order.php
@@ -22,18 +22,18 @@ class KCO_Request_Upsell_Order extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $klarna_order_id, $order_id, $upsell_uuid ) {
-		$this->request_url = $this->get_api_url_base() . 'ordermanagement/v1/orders/' . $klarna_order_id . '/authorization';
-		$request_args      = apply_filters( 'kco_wc_acknowledge_order', $this->get_request_args( $order_id, $upsell_uuid ) );
+		$request_url  = $this->get_api_url_base() . 'ordermanagement/v1/orders/' . $klarna_order_id . '/authorization';
+		$request_args = apply_filters( 'kco_wc_acknowledge_order', $this->get_request_args( $order_id, $upsell_uuid, $request_url ) );
 
 		$body_array           = apply_filters( 'kco_wc_api_request_args', json_decode( $request_args['body'], true ), $order_id, $upsell_uuid );
 		$request_args['body'] = wp_json_encode( $body_array );
 
-		$response          = wp_remote_request( $this->request_url, $request_args );
+		$response          = wp_remote_request( $request_url, $request_args );
 		$code              = wp_remote_retrieve_response_code( $response );
-		$formated_response = $this->process_response( $response, $request_args, $this->request_url );
+		$formated_response = $this->process_response( $response, $request_args, $request_url );
 
 		// Log the request.
-		$log = KCO_Logger::format_log( $klarna_order_id, 'PATCH', 'KCO upsell order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
+		$log = KCO_Logger::format_log( $klarna_order_id, 'PATCH', 'KCO upsell order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
 		KCO_Logger::log( $log );
 		return $formated_response;
 	}
@@ -59,12 +59,13 @@ class KCO_Request_Upsell_Order extends KCO_Request {
 	 *
 	 * @param int    $order_id The WooCommerce order id.
 	 * @param string $upsell_uuid The unique id for the upsell request.
+	 * @param string $url The request URL.
 	 * @return array
 	 */
-	protected function get_request_args( $order_id, $upsell_uuid ) {
+	protected function get_request_args( $order_id, $upsell_uuid, $url = '' ) {
 		return array(
 			'headers'    => $this->get_request_headers(),
-			'user-agent' => $this->get_user_agent(),
+			'user-agent' => $this->get_user_agent( $url ),
 			'method'     => 'PATCH',
 			'body'       => wp_json_encode( $this->get_body( $order_id, $upsell_uuid ) ),
 			'timeout'    => apply_filters( 'kco_wc_request_timeout', 10 ),

--- a/classes/requests/order-management/patch/class-kco-request-upsell-order.php
+++ b/classes/requests/order-management/patch/class-kco-request-upsell-order.php
@@ -50,7 +50,7 @@ class KCO_Request_Upsell_Order extends KCO_Request {
 		return array(
 			'order_lines'  => $helper->get_order_lines( $order_id ),
 			'order_amount' => $helper->get_order_amount( $order_id ),
-			'description'  => __( 'Upsell from thankyou page', 'klarna-upsell-for-woocommerce' ),
+			'description'  => __( 'Upsell from thankyou page', 'klarna-upsell-for-woocommerce' ), // phpcs:ignore
 		);
 	}
 

--- a/classes/requests/order-management/post/class-kco-request-acknowledge-order.php
+++ b/classes/requests/order-management/post/class-kco-request-acknowledge-order.php
@@ -20,14 +20,14 @@ class KCO_Request_Acknowledge_Order extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $klarna_order_id ) {
-		$request_url       = $this->get_api_url_base() . 'ordermanagement/v1/orders/' . $klarna_order_id . '/acknowledge';
+		$this->request_url = $this->get_api_url_base() . 'ordermanagement/v1/orders/' . $klarna_order_id . '/acknowledge';
 		$request_args      = apply_filters( 'kco_wc_acknowledge_order', $this->get_request_args() );
-		$response          = wp_remote_request( $request_url, $request_args );
+		$response          = wp_remote_request( $this->request_url, $request_args );
 		$code              = wp_remote_retrieve_response_code( $response );
-		$formated_response = $this->process_response( $response, $request_args, $request_url );
+		$formated_response = $this->process_response( $response, $request_args, $this->request_url );
 
 		// Log the request.
-		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO acknowledge order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
+		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO acknowledge order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
 		KCO_Logger::log( $log );
 		return $formated_response;
 	}

--- a/classes/requests/order-management/post/class-kco-request-acknowledge-order.php
+++ b/classes/requests/order-management/post/class-kco-request-acknowledge-order.php
@@ -20,14 +20,14 @@ class KCO_Request_Acknowledge_Order extends KCO_Request {
 	 * @return array
 	 */
 	public function request( $klarna_order_id ) {
-		$this->request_url = $this->get_api_url_base() . 'ordermanagement/v1/orders/' . $klarna_order_id . '/acknowledge';
-		$request_args      = apply_filters( 'kco_wc_acknowledge_order', $this->get_request_args() );
-		$response          = wp_remote_request( $this->request_url, $request_args );
+		$request_url       = $this->get_api_url_base() . 'ordermanagement/v1/orders/' . $klarna_order_id . '/acknowledge';
+		$request_args      = apply_filters( 'kco_wc_acknowledge_order', $this->get_request_args( $request_url ) );
+		$response          = wp_remote_request( $request_url, $request_args );
 		$code              = wp_remote_retrieve_response_code( $response );
-		$formated_response = $this->process_response( $response, $request_args, $this->request_url );
+		$formated_response = $this->process_response( $response, $request_args, $request_url );
 
 		// Log the request.
-		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO acknowledge order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $this->request_url );
+		$log = KCO_Logger::format_log( $klarna_order_id, 'POST', 'KCO acknowledge order', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
 		KCO_Logger::log( $log );
 		return $formated_response;
 	}
@@ -35,12 +35,13 @@ class KCO_Request_Acknowledge_Order extends KCO_Request {
 	/**
 	 * Gets the request args for the API call.
 	 *
+	 * @param string $url The request URL.
 	 * @return array
 	 */
-	protected function get_request_args() {
+	protected function get_request_args( $url = '' ) {
 		return array(
 			'headers'    => $this->get_request_headers(),
-			'user-agent' => $this->get_user_agent(),
+			'user-agent' => $this->get_user_agent( $url ),
 			'method'     => 'POST',
 			'timeout'    => apply_filters( 'kco_wc_request_timeout', 10 ),
 		);


### PR DESCRIPTION
The [`http_headers_useragent` filter](https://developer.wordpress.org/reference/hooks/http_headers_useragent/) hook which we apply expect a `$url` as a 2nd parameter which we're not passing. This has resulted in plugin that hook onto this filter unexpectedly processing a `null` value which would break functionality due to this assumption.

This PR includes the current Kustom request URL as the 2nd parameter.

https://app.clickup.com/t/869cu403f 