### PR TITLE
Improved EPM control

### DIFF
--- a/.changelogs/2026-04-23-improved-epm-redirect-check
+++ b/.changelogs/2026-04-23-improved-epm-redirect-check
@@ -1,0 +1,4 @@
+Type: Enhancement
+Needs Documentation: yes
+
+Improved the control on external payment method redirects to ensure the correct WooCommerce order is used when placing the order.

--- a/classes/class-kco-confirmation.php
+++ b/classes/class-kco-confirmation.php
@@ -138,7 +138,7 @@ class KCO_Confirmation {
 		}
 
 		// Ensure the Kustom order has the correct merchant reference 2 that matches the WooCommerce order id.
-		if ( $wc_order_id !== absint( $merchant_ref_2 ) ) {
+		if ( absint( $merchant_ref_2 ) !== $wc_order_id ) {
 			KCO_Logger::log( "Failed EPM validation: merchant_reference2 ({$merchant_ref_2}) does not match the WooCommerce order id. {$log_context}." );
 			return false;
 		}

--- a/classes/class-kco-confirmation.php
+++ b/classes/class-kco-confirmation.php
@@ -9,6 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Krokedil\KustomCheckout\Utility\SigningKeyUtility;
+
 /**
  * KCO_Confirmation class.
  *
@@ -92,6 +94,65 @@ class KCO_Confirmation {
 	}
 
 	/**
+	 * Validate the EPM order to ensure we should continue with the EPM purchase or not.
+	 *
+	 * @param string   $kustom_order_id The Kustom order id.
+	 * @param string   $epm The name of the external payment method.
+	 * @param WC_Order $order The WooCommerce order object.
+	 * @return bool True if the order is valid for processing the external payment, false if not.
+	 */
+	private function validate_epm_order( $kustom_order_id, $epm, $order ) {
+		$wc_order_id     = $order->get_id();
+		$wc_order_number = $order->get_order_number();
+		$log_context     = "Kustom order id {$kustom_order_id}, WC order id {$wc_order_id} (number {$wc_order_number}), external payment {$epm}";
+
+		// Get the Kustom order details from the API to be able to validate the order.
+		$kustom_order = KCO_WC()->api->get_klarna_order( $kustom_order_id );
+
+		// Ensure we got a valid Kustom order response.
+		if ( is_wp_error( $kustom_order ) || empty( $kustom_order ) ) {
+			KCO_Logger::log( "Failed to retrieve Kustom order for EPM validation. {$log_context}." );
+			return false;
+		}
+
+		$kustom_status  = $kustom_order['status'] ?? '';
+		$merchant_ref_1 = $kustom_order['merchant_reference1'] ?? '';
+		$merchant_ref_2 = $kustom_order['merchant_reference2'] ?? '';
+
+		// Validate the signing key to ensure the order is valid and was not tampered with.
+		if ( ! SigningKeyUtility::validate_from_kustom_order( $kustom_order, $kustom_order_id ) ) {
+			KCO_Logger::log( "Failed to validate the signing key from the Kustom order. {$log_context}." );
+			return false;
+		}
+
+		// Ensure the Kustom order is in the correct status.
+		if ( 'checkout_incomplete' !== $kustom_status ) {
+			KCO_Logger::log( "The Kustom order is in status {$kustom_status} which is not valid for EPM. {$log_context}." );
+			return false;
+		}
+
+		// Ensure the Kustom order has the correct merchant reference 1 that matches the WooCommerce order number.
+		if ( $wc_order_number !== $merchant_ref_1 ) {
+			KCO_Logger::log( "Failed EPM validation: merchant_reference1 ({$merchant_ref_1}) does not match the WooCommerce order number. {$log_context}." );
+			return false;
+		}
+
+		// Ensure the Kustom order has the correct merchant reference 2 that matches the WooCommerce order id.
+		if ( $wc_order_id !== absint( $merchant_ref_2 ) ) {
+			KCO_Logger::log( "Failed EPM validation: merchant_reference2 ({$merchant_ref_2}) does not match the WooCommerce order id. {$log_context}." );
+			return false;
+		}
+
+		// Ensure the WooCommerce order has the correct Kustom order id stored in the meta.
+		if ( $order->get_meta( '_wc_klarna_order_id' ) !== $kustom_order_id ) {
+			KCO_Logger::log( "Failed EPM validation: the WooCommerce order does not have the correct Kustom order id stored in the meta. {$log_context}." );
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Initiates a Kustom External Payment Method payment.
 	 *
 	 * @param string $epm The name of the external payment method.
@@ -113,26 +174,49 @@ class KCO_Confirmation {
 
 		// Check if we have a order.
 		if ( empty( $order ) ) {
-			wc_print_notice( __( 'Failed getting the order for the external payment.', 'klarna-checkout-for-woocommerce' ), 'error' );
+			wc_add_notice( __( 'Failed getting the order for the external payment.', 'klarna-checkout-for-woocommerce' ), 'error' );
+			return;
+		}
+
+		if ( empty( $klarna_order_id ) ) {
+			/**
+			 * Deprecated notice for missing Kustom order id in EPM URL.
+			 *
+			 * This is done to make sure that existing integrations that use external payment methods without including the Kustom order id in the URL do not break immediately.
+			 * But in the future this will be required to be able to properly verify the order,
+			 * and prevent the wrong order being processed in cases where multiple orders have been created in WooCommerce with the same KCO order id.
+			 *
+			 * To add this to your integration, make sure to include the Kustom order id in the URL as a kco_order_id parameter by adding &kco_order_id={checkout.order.id} to the redirect URL when registering the EPM.
+			 *
+			 * @see https://docs.krokedil.com/kustom-checkout-for-woocommerce/customization/external-payment-method-epm/#example-code-bacs
+			 */
+			KCO_Logger::log( "Running external payment method {$epm} without Kustom order id in the URL. This will be required in the future to ensure proper verification of the order." );
+			wc_deprecated_argument( 'run_kepm', '2.20.0', 'Please include the Kustom order id in the redirect URL by adding &kco_order_id={checkout.order.id} when registering the EPM. If this is not done, the external payment method may not function correctly in the future.' );
+		} elseif ( ! $this->validate_epm_order( $klarna_order_id, $epm, $order ) ) { // If we fail to validate the purchase, we should not continue with processing the external payment.
+			wc_add_notice( __( 'We couldn\'t verify your payment. Please try again.', 'klarna-checkout-for-woocommerce' ), 'error' );
 			return;
 		}
 
 		$payment_methods = WC()->payment_gateways->get_available_payment_gateways();
+
 		// Check if the payment method is available.
 		if ( ! isset( $payment_methods[ $epm ] ) ) {
-			wc_print_notice( __( 'Failed to find the payment method for the external payment.', 'klarna-checkout-for-woocommerce' ), 'error' );
+			wc_add_notice( __( 'Failed to find the payment method for the external payment.', 'klarna-checkout-for-woocommerce' ), 'error' );
 			return;
 		}
+
 		// Everything is fine, redirect to the URL specified by the gateway.
 		WC()->session->set( 'chosen_payment_method', $epm );
 		$order->set_payment_method( $payment_methods[ $epm ] );
 		$order->save();
 		$result = $payment_methods[ $epm ]->process_payment( $order_id );
+
 		// Check if the result is good.
 		if ( ! isset( $result['result'] ) || 'success' !== $result['result'] ) {
-			wc_print_notice( __( 'Something went wrong with the external payment. Please try again', 'klarna-checkout-for-woocommerce' ), 'error' );
+			wc_add_notice( __( 'Something went wrong with the external payment. Please try again', 'klarna-checkout-for-woocommerce' ), 'error' );
 			return;
 		}
+
 		wp_redirect( $result['redirect'] ); // phpcs:ignore
 		exit;
 	}

--- a/classes/requests/checkout/post/class-kco-request-create.php
+++ b/classes/requests/checkout/post/class-kco-request-create.php
@@ -52,7 +52,7 @@ class KCO_Request_Create extends KCO_Request {
 			'merchant_urls'      => KCO_WC()->merchant_urls->get_urls( $order_id ),
 			'billing_countries'  => KCO_Request_Countries::get_billing_countries(),
 			'shipping_countries' => KCO_Request_Countries::get_shipping_countries(),
-			'merchant_data'      => KCO_Request_Merchant_Data::get_merchant_data(),
+			'merchant_data'      => KCO_Request_Merchant_Data::get_merchant_data( $order_id ),
 			'options'            => $request_options->get_options( $checkout_flow ),
 			'customer'           => array(
 				'type' => ( in_array( $this->settings['allowed_customer_types'], array( 'B2B', 'B2BC' ), true ) ) ? 'organization' : 'person',

--- a/classes/requests/checkout/post/class-kco-request-update.php
+++ b/classes/requests/checkout/post/class-kco-request-update.php
@@ -63,7 +63,7 @@ class KCO_Request_Update extends KCO_Request {
 			'order_tax_amount'   => $cart_data->get_order_tax_amount( $cart_data->get_order_lines() ),
 			'billing_countries'  => KCO_Request_Countries::get_billing_countries(),
 			'shipping_countries' => KCO_Request_Countries::get_shipping_countries(),
-			'merchant_data'      => KCO_Request_Merchant_Data::get_merchant_data(),
+			'merchant_data'      => KCO_Request_Merchant_Data::get_merchant_data( $order_id ),
 			'options'            => $request_options->get_options(),
 		);
 

--- a/classes/requests/helpers/class-kco-request-merchant-data.php
+++ b/classes/requests/helpers/class-kco-request-merchant-data.php
@@ -9,6 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Krokedil\KustomCheckout\Utility\SigningKeyUtility;
+
 /**
  * KCO_Request_Merchant_Data class.
  *
@@ -18,10 +20,12 @@ class KCO_Request_Merchant_Data {
 	/**
 	 * Gets merchant data for Kustom purchase.
 	 *
+	 * @param int|null $order_id The WooCommerce order ID, if available.
 	 * @return array
 	 */
-	public static function get_merchant_data() {
+	public static function get_merchant_data( $order_id = null ) {
 		$merchant_data = array();
+		$order         = $order_id ? wc_get_order( $order_id ) : null;
 
 		// Coupon info.
 		foreach ( WC()->cart->get_applied_coupons() as $coupon ) {
@@ -30,6 +34,7 @@ class KCO_Request_Merchant_Data {
 
 		// Is user logged in.
 		$merchant_data['is_user_logged_in'] = is_user_logged_in();
+		$merchant_data['signing_key']       = SigningKeyUtility::from_wc_order_kco_id( $order ) ?? SigningKeyUtility::from_session_kco_id();
 
 		return wp_json_encode( $merchant_data );
 	}

--- a/src/Utility/SigningKeyUtility.php
+++ b/src/Utility/SigningKeyUtility.php
@@ -35,13 +35,10 @@ class SigningKeyUtility {
 	 * @return string|null The generated signing key, or null if the Kustom order ID is not available in the order.
 	 */
 	public static function from_wc_order_kco_id( $order ) {
-		// If the order is an ID, we need to get the order object.
-		if ( is_numeric( $order ) ) {
-			$order = wc_get_order( $order );
-		}
+		$order = wc_get_order( $order );
 
-		// If we still don't have an order object, we can return null.
-		if ( ! $order instanceof \WC_Order ) {
+		// Ensure we have a valid order object.
+		if ( ! $order ) {
 			return null;
 		}
 

--- a/src/Utility/SigningKeyUtility.php
+++ b/src/Utility/SigningKeyUtility.php
@@ -1,0 +1,110 @@
+<?php
+namespace Krokedil\KustomCheckout\Utility;
+
+/**
+ * Class SigningKeyUtility
+ *
+ * Helper class to generate and validate signing keys used in the callbacks or redirects from Kustom.
+ */
+class SigningKeyUtility {
+	/**
+	 * Generate a signing key using the Kustom order id stored in the WooCommerce session.
+	 *
+	 * @return string|null The generated signing key, or null if the Kustom order ID is not available in the session.
+	 */
+	public static function from_session_kco_id() {
+		// Ensure the WooCommerce session is available.
+		if ( ! WC()->session ) {
+			return null;
+		}
+
+		$kustom_order_id = WC()->session->get( 'kco_wc_order_id' );
+
+		if ( ! $kustom_order_id ) {
+			return null;
+		}
+
+		return self::generate( $kustom_order_id );
+	}
+
+	/**
+	 * Generate a signing key using the Kustom order id stored in the WooCommerce order.
+	 *
+	 * @param \WC_Order|int|null $order The WooCommerce order object, id or null.
+	 *
+	 * @return string|null The generated signing key, or null if the Kustom order ID is not available in the order.
+	 */
+	public static function from_wc_order_kco_id( $order ) {
+		// If the order is an ID, we need to get the order object.
+		if ( is_numeric( $order ) ) {
+			$order = wc_get_order( $order );
+		}
+
+		// If we still don't have an order object, we can return null.
+		if ( ! $order instanceof \WC_Order ) {
+			return null;
+		}
+
+		$kustom_order_id = $order->get_meta( '_wc_klarna_order_id' );
+
+		if ( ! $kustom_order_id ) {
+			return null;
+		}
+
+		return self::generate( $kustom_order_id );
+	}
+
+	/**
+	 * Validate a signing key from the Kustom order.
+	 *
+	 * @param array  $kustom_order The Kustom order data, which should contain the signing key in the 'merchant_data' field.
+	 * @param string $value The value that was signed, typically the Kustom order ID.
+	 *
+	 * @return bool True if the signing key is valid, false otherwise.
+	 */
+	public static function validate_from_kustom_order( $kustom_order, $value ) {
+		if ( ! isset( $kustom_order['merchant_data'] ) ) {
+			return false;
+		}
+
+		$merchant_data = json_decode( $kustom_order['merchant_data'], true );
+
+		if ( ! isset( $merchant_data['signing_key'] ) ) {
+			return false;
+		}
+
+		return self::validate( $value, $merchant_data['signing_key'] );
+	}
+
+	/**
+	 * Generate a signing key based on the provided parameters.
+	 *
+	 * @param string $value The value to be signed, typically something unique for the order, like the order ID.
+	 *
+	 * @return string The generated signing key.
+	 */
+	public static function generate( $value ) {
+		return hash_hmac( 'sha256', $value, self::get_secret_key() );
+	}
+
+	/**
+	 * Validate a given signing key against the expected value.
+	 *
+	 * @param string $value The value that was signed, typically the order ID.
+	 * @param string $provided_key The signing key provided in the callback or redirect.
+	 *
+	 * @return bool True if the provided signing key is valid, false otherwise.
+	 */
+	public static function validate( $value, $provided_key ) {
+		return hash_equals( self::generate( $value ), $provided_key );
+	}
+
+	/**
+	 * Get the secret key using the WordPress salt function, which provides a unique and secure key for signing.
+	 *
+	 * @return string The secret key used for generating signing keys.
+	 */
+	private static function get_secret_key() {
+		return wp_salt( 'auth' );
+	}
+}


### PR DESCRIPTION
Ensures the WooCommerce and Kustom order matches when processing an EPM payment.

**Note:** This adds a deprecation notice to the EPM flow if the Kustom order id is missing from the query params. In a later version this will be made mandatory, so integrations will need to update their redirect URL to match the new requirements.

Before we make a release with this, we should make sure the version number set for the deprecation is the correct version number as well [here](https://github.com/krokedil/klarna-checkout-for-woocommerce/blob/7b92d1ea5210498d75303c46076a7b4c5594b8b3/classes/class-kco-confirmation.php#L194) instead of the assumed 2.20.0 i added for now.