### PR TITLE
Reload checkout on BAD_VALUE currency error

### DIFF
--- a/.changelogs/2026-05-18-reload-bad-currency
+++ b/.changelogs/2026-05-18-reload-bad-currency
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed an issue that could allow customers from unsupported countries to complete checkout and place an order.

--- a/classes/class-kco-api.php
+++ b/classes/class-kco-api.php
@@ -26,8 +26,13 @@ class KCO_API {
 	public function create_klarna_order( $order_id = false, $checkout_flow = 'embedded' ) {
 		$request  = new KCO_Request_Create();
 		$response = $request->request( $order_id, $checkout_flow );
+		$result   = $this->check_for_api_error( $response );
 
-		return $this->check_for_api_error( $response );
+		if ( $result ) {
+			WC()->session->set( 'kco_bad_value_reload_attempted', false );
+		}
+
+		return $result;
 	}
 
 	/**
@@ -93,6 +98,26 @@ class KCO_API {
 
 					wp_safe_redirect( $redirect_url );
 					exit;
+				}
+			}
+
+			// Handle BAD_VALUE purchase_currency mismatch (e.g. customer changes country to one incompatible
+			// with the store currency). Reload the checkout once so WC can display the "not available" message
+			// instead of surfacing the raw Klarna error. The one-shot flag prevents an infinite reload loop.
+			if ( is_array( $error ) && 'BAD_VALUE' === ( $error['error_code'] ?? false ) ) {
+				$has_currency_error = false;
+				foreach ( $error['error_messages'] ?? array() as $message ) {
+					if ( false !== strpos( $message, 'purchase_currency' ) ) {
+						$has_currency_error = true;
+						break;
+					}
+				}
+				if ( $has_currency_error && ! WC()->session->get( 'kco_bad_value_reload_attempted' ) ) {
+					WC()->session->set( 'kco_bad_value_reload_attempted', true );
+					WC()->session->set( 'kco_wc_order_id', null );
+					WC()->session->set( 'reload_checkout', true );
+					KCO_Logger::log( 'Klarna BAD_VALUE purchase_currency mismatch for order ' . $klarna_order_id . '. Reloading checkout.' );
+					return false;
 				}
 			}
 		}

--- a/classes/class-kco-api.php
+++ b/classes/class-kco-api.php
@@ -101,9 +101,8 @@ class KCO_API {
 				}
 			}
 
-			// Handle BAD_VALUE purchase_currency mismatch (e.g. customer changes country to one incompatible
-			// with the store currency). Reload the checkout once so WC can display the "not available" message
-			// instead of surfacing the raw Klarna error. The one-shot flag prevents an infinite reload loop.
+			// Handle BAD_VALUE purchase_currency mismatch (e.g. customer changes country to one incompatible with the store currency).
+			// In this case we want to reload the checkout and try again, but only once to avoid infinite reload loops.
 			if ( is_array( $error ) && 'BAD_VALUE' === ( $error['error_code'] ?? false ) ) {
 				$has_currency_error = false;
 				foreach ( $error['error_messages'] ?? array() as $message ) {
@@ -114,7 +113,6 @@ class KCO_API {
 				}
 				if ( $has_currency_error && ! WC()->session->get( 'kco_bad_value_reload_attempted' ) ) {
 					WC()->session->set( 'kco_bad_value_reload_attempted', true );
-					WC()->session->set( 'kco_wc_order_id', null );
 					WC()->session->set( 'reload_checkout', true );
 					KCO_Logger::log( 'Klarna BAD_VALUE purchase_currency mismatch for order ' . $klarna_order_id . '. Reloading checkout.' );
 					return false;

--- a/classes/class-kco-api.php
+++ b/classes/class-kco-api.php
@@ -26,9 +26,7 @@ class KCO_API {
 	public function create_klarna_order( $order_id = false, $checkout_flow = 'embedded' ) {
 		$request  = new KCO_Request_Create();
 		$response = $request->request( $order_id, $checkout_flow );
-		$result   = $this->check_for_api_error( $response );
-
-		return $result;
+		return $this->check_for_api_error( $response );
 	}
 
 	/**

--- a/classes/class-kco-api.php
+++ b/classes/class-kco-api.php
@@ -26,6 +26,7 @@ class KCO_API {
 	public function create_klarna_order( $order_id = false, $checkout_flow = 'embedded' ) {
 		$request  = new KCO_Request_Create();
 		$response = $request->request( $order_id, $checkout_flow );
+
 		return $this->check_for_api_error( $response );
 	}
 

--- a/classes/class-kco-api.php
+++ b/classes/class-kco-api.php
@@ -28,10 +28,6 @@ class KCO_API {
 		$response = $request->request( $order_id, $checkout_flow );
 		$result   = $this->check_for_api_error( $response );
 
-		if ( $result ) {
-			WC()->session->set( 'kco_bad_value_reload_attempted', false );
-		}
-
 		return $result;
 	}
 
@@ -102,7 +98,6 @@ class KCO_API {
 			}
 
 			// Handle BAD_VALUE purchase_currency mismatch (e.g. customer changes country to one incompatible with the store currency).
-			// In this case we want to reload the checkout and try again, but only once to avoid infinite reload loops.
 			if ( is_array( $error ) && 'BAD_VALUE' === ( $error['error_code'] ?? false ) ) {
 				$has_currency_error = false;
 				foreach ( $error['error_messages'] ?? array() as $message ) {
@@ -111,8 +106,7 @@ class KCO_API {
 						break;
 					}
 				}
-				if ( $has_currency_error && ! WC()->session->get( 'kco_bad_value_reload_attempted' ) ) {
-					WC()->session->set( 'kco_bad_value_reload_attempted', true );
+				if ( $has_currency_error ) {
 					WC()->session->set( 'reload_checkout', true );
 					KCO_Logger::log( 'Klarna BAD_VALUE purchase_currency mismatch for order ' . $klarna_order_id . '. Reloading checkout.' );
 					return false;


### PR DESCRIPTION
This resolves that customers could simply ignore the `{"error_code":"BAD_VALUE","error_messages":["Bad value: purchase_currency (order billing country is: NO, configured currencies are: AUD, CAD, CHF, DKK, EUR, GBP, NOK, USD)"],"correlation_id":"bdcd8136-7654-4789-8780-5e4edca741e2","service_version":"SNAPSHOT"} Bad value: purchase_currency (order billing country is: NO, configured currencies are: AUD, CAD, CHF, DKK, EUR, GBP, NOK, USD)` error and place an order from an unsupported country.