### PR TITLE
Use latest version of the support package

### DIFF
--- a/.changelogs/2026-05-22-disable-autoloading-support
+++ b/.changelogs/2026-05-22-disable-autoloading-support
@@ -1,0 +1,4 @@
+Type: Enhancement
+Needs Documentation: no
+
+[Support] Explicitly disabled autoloading the system report option to prevent it from being loaded on every request, as it is only needed when issuing a request, and viewing the system report.

--- a/.changelogs/2026-05-22-undefined-array-key
+++ b/.changelogs/2026-05-22-undefined-array-key
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+[Support] The $form_field variable can sometimes be missing keys that are available in the $setting array when "MU"-plugins are used. Added a check to ensure that the keys exist in both arrays before attempting to access them, preventing potential undefined key errors.

--- a/composer-dependencies.json
+++ b/composer-dependencies.json
@@ -2,7 +2,7 @@
     "require": {
         "php": ">=7.4",
         "krokedil/woocommerce": "^1.0",
-        "krokedil/support": "1.0.2",
+        "krokedil/support": "1.0.4",
         "krokedil/settings-page": "^1.1.0"
     },
     "config": {

--- a/composer-dependencies.lock
+++ b/composer-dependencies.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a268637b4eb3a48d9e12690a6824d424",
+    "content-hash": "dc3bb960232843bf802f99d1ee605c38",
     "packages": [
         {
             "name": "krokedil/settings-page",
@@ -53,16 +53,16 @@
         },
         {
             "name": "krokedil/support",
-            "version": "1.0.2",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/krokedil/support.git",
-                "reference": "99059b1b27cc4ed7667c1d04968aec45413fe533"
+                "reference": "96da75792434a2553c6af9e891e646705fd33e7c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/krokedil/support/zipball/99059b1b27cc4ed7667c1d04968aec45413fe533",
-                "reference": "99059b1b27cc4ed7667c1d04968aec45413fe533",
+                "url": "https://api.github.com/repos/krokedil/support/zipball/96da75792434a2553c6af9e891e646705fd33e7c",
+                "reference": "96da75792434a2553c6af9e891e646705fd33e7c",
                 "shasum": ""
             },
             "require": {
@@ -102,10 +102,10 @@
             ],
             "description": "The support library allows you to extend your plugin with logging that can be optionally toggled through your plugin settings, generate an entry in the system report from your plugin settings, and report issues to the system report.",
             "support": {
-                "source": "https://github.com/krokedil/support/tree/1.0.2",
+                "source": "https://github.com/krokedil/support/tree/1.0.4",
                 "issues": "https://github.com/krokedil/support/issues"
             },
-            "time": "2025-10-08T12:47:46+00:00"
+            "time": "2026-04-20T16:27:59+00:00"
         },
         {
             "name": "krokedil/woocommerce",


### PR DESCRIPTION
Use latest version of the support package, to include the solution of the "Undefined array key" warning issue.