### PR TITLE
Improved checkout debug logging

### DIFF
--- a/.changelogs/2026-06-03-checkout-error-details-dropped-from-debug-log
+++ b/.changelogs/2026-06-03-checkout-error-details-dropped-from-debug-log
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed a bug where checkout error details could be silently dropped from the debug log.

--- a/.changelogs/2026-06-03-richer-checkout-error-log-entries
+++ b/.changelogs/2026-06-03-richer-checkout-error-log-entries
@@ -1,0 +1,4 @@
+Type: Tweak
+Needs Documentation: no
+
+Checkout error log entries now include the error type and HTTP status code, making it faster to diagnose failed orders.

--- a/assets/js/klarna-checkout-for-woocommerce.js
+++ b/assets/js/klarna-checkout-for-woocommerce.js
@@ -476,7 +476,7 @@ jQuery( function ( $ ) {
 				type: "POST",
 				dataType: "json",
 				data: {
-					message: message,
+					message: typeof message === "object" ? JSON.stringify( message ) : message,
 					nonce: kco_params.log_to_file_nonce,
 				},
 			} )
@@ -541,10 +541,10 @@ jQuery( function ( $ ) {
 								}
 							} catch ( err ) {
 								if ( data.messages ) {
-									kco_wc.logToFile( "Checkout error | " + data.messages )
+									kco_wc.logToFile( { type: "checkout_error", message: data.messages } )
 									kco_wc.failOrder( "submission", data.messages, callback )
 								} else {
-									kco_wc.logToFile( "Checkout error | No message" )
+									kco_wc.logToFile( { type: "checkout_error", message: "No message" } )
 									kco_wc.failOrder(
 										"submission",
 										'<div class="woocommerce-error">Checkout error</div>',
@@ -554,11 +554,12 @@ jQuery( function ( $ ) {
 							}
 						},
 						error: function ( data ) {
-							try {
-								kco_wc.logToFile( "AJAX error | " + JSON.stringify( data ) )
-							} catch ( e ) {
-								kco_wc.logToFile( "AJAX error | Failed to parse error message." )
-							}
+							const isHtmlResponse = ( data.responseText || "" ).trimStart().startsWith( "<" )
+							kco_wc.logToFile( {
+								type:     "ajax_error",
+								status:   data.status,
+								response: isHtmlResponse ? "[HTML body stripped]" : ( data.responseText || "" ),
+							} )
 							kco_wc.failOrder(
 								"ajax-error",
 								'<div class="woocommerce-error">Internal Server Error</div>',

--- a/classes/class-kco-ajax.php
+++ b/classes/class-kco-ajax.php
@@ -254,6 +254,14 @@ class KCO_AJAX extends WC_AJAX {
 		check_ajax_referer( 'kco_wc_log_js', 'nonce' );
 		$kustom_order_id = WC()->session->get( 'kco_wc_order_id' );
 
+		$raw_message = filter_input( INPUT_POST, 'message' ) ?? '';
+
+		// If the message is too long, log an error message and return.
+		if ( strlen( $raw_message ) > 1024 ) {
+			KCO_Logger::log( "Frontend JS Kustom:{$kustom_order_id}: message too long and can't be logged." ); // Return success to not stop anything in the frontend if this happens.
+			wp_send_json_success();
+			return;
+		}
 		$base_context = array(
 			'id'     => $kustom_order_id,
 			'source' => 'kustom-checkout-for-woocommerce',
@@ -262,8 +270,6 @@ class KCO_AJAX extends WC_AJAX {
 		$decoded      = json_decode( $raw_message, true );
 		$allowed_keys = array( 'type', 'message', 'status', 'response' );
 
-		// Get the content size of the request.
-		$post_size = (int) $_SERVER['CONTENT_LENGTH'] ?? 0;
 		if ( is_array( $decoded ) ) {
 			$filtered    = array_intersect_key( $decoded, array_flip( $allowed_keys ) );
 			$log_context = array_merge( array_map( 'sanitize_text_field', $filtered ), $base_context );

--- a/classes/class-kco-ajax.php
+++ b/classes/class-kco-ajax.php
@@ -277,10 +277,7 @@ class KCO_AJAX extends WC_AJAX {
 			$log_context = array_merge( array( 'message' => sanitize_text_field( $raw_message ) ), $base_context );
 		}
 
-		$settings = get_option( 'woocommerce_kco_settings' );
-		if ( 'yes' === ( $settings['logging'] ?? '' ) ) {
-			wc_get_logger()->log( 'notice', 'Frontend JS', $log_context );
-		}
+		KCO_Logger::log( array_merge( array( 'title' => 'Frontend JS' ), $log_context ) );
 
 		wp_send_json_success();
 	}

--- a/classes/class-kco-ajax.php
+++ b/classes/class-kco-ajax.php
@@ -252,20 +252,30 @@ class KCO_AJAX extends WC_AJAX {
 	 */
 	public static function kco_wc_log_js() {
 		check_ajax_referer( 'kco_wc_log_js', 'nonce' );
-		$klarna_order_id = WC()->session->get( 'kco_wc_order_id' );
+		$kustom_order_id = WC()->session->get( 'kco_wc_order_id' );
+
+		$base_context = array(
+			'id'     => $kustom_order_id,
+			'source' => 'kustom-checkout-for-woocommerce',
+		);
+
+		$decoded      = json_decode( $raw_message, true );
+		$allowed_keys = array( 'type', 'message', 'status', 'response' );
 
 		// Get the content size of the request.
 		$post_size = (int) $_SERVER['CONTENT_LENGTH'] ?? 0;
-
-		// If the post data is to long, log a error message and return.
-		if ( $post_size > 1024 ) {
-			KCO_Logger::log( "Frontend JS $klarna_order_id: message to long and can't be logged." );
-			wp_send_json_success(); // Return success to not stop anything in the frontend if this happens.
+		if ( is_array( $decoded ) ) {
+			$filtered    = array_intersect_key( $decoded, array_flip( $allowed_keys ) );
+			$log_context = array_merge( array_map( 'sanitize_text_field', $filtered ), $base_context );
+		} else {
+			$log_context = array_merge( array( 'message' => sanitize_text_field( $raw_message ) ), $base_context );
 		}
 
-		$posted_message = filter_input( INPUT_POST, 'message', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
-		$message        = "Frontend JS $klarna_order_id: $posted_message";
-		KCO_Logger::log( $message );
+		$settings = get_option( 'woocommerce_kco_settings' );
+		if ( 'yes' === ( $settings['logging'] ?? '' ) ) {
+			wc_get_logger()->log( 'notice', 'Frontend JS', $log_context );
+		}
+
 		wp_send_json_success();
 	}
 

--- a/src/CheckoutFlow/CheckoutFlow.php
+++ b/src/CheckoutFlow/CheckoutFlow.php
@@ -25,10 +25,15 @@ abstract class CheckoutFlow {
 			throw new Exception( esc_html( $message ) );
 		}
 		$handler         = self::get_handler();
-		$meta_id         = $order->get_meta( '_wc_klarna_order_id', true );
-		$kustom_order_id = $meta_id ? $meta_id : ( WC()->session?->get( 'kco_wc_order_id' ) ?? 'N/A' );
+		$kustom_order_id = $order->get_meta( '_wc_klarna_order_id', true );
+		if ( empty( $kustom_order_id ) && WC()->session ) {
+			$kustom_order_id = WC()->session->get( 'kco_wc_order_id' );
+		}
+		if ( empty( $kustom_order_id ) ) {
+			$kustom_order_id = 'N/A';
+		}
 
-		\KCO_Logger::log( sprintf( 'Processing order %s|%s (Kustom ID: %s) with flow %s.', $order->get_id(), $order->get_order_number(), $kustom_order_id, get_class( $handler ) ) );
+		\KCO_Logger::log( \sprintf( 'Processing order %s|%s (Kustom ID: %s) with flow %s.', $order->get_id(), $order->get_order_number(), $kustom_order_id, \get_class( $handler ) ) );
 
 		return $handler->process( $order );
 	}

--- a/src/CheckoutFlow/CheckoutFlow.php
+++ b/src/CheckoutFlow/CheckoutFlow.php
@@ -25,7 +25,8 @@ abstract class CheckoutFlow {
 			throw new Exception( esc_html( $message ) );
 		}
 		$handler         = self::get_handler();
-		$kustom_order_id = $order->get_meta( '_wc_klarna_order_id', true ) ?: ( WC()->session ? WC()->session->get( 'kco_wc_order_id' ) : null ) ?? 'N/A';
+		$meta_id         = $order->get_meta( '_wc_klarna_order_id', true );
+		$kustom_order_id = $meta_id ? $meta_id : ( WC()->session?->get( 'kco_wc_order_id' ) ?? 'N/A' );
 
 		\KCO_Logger::log( sprintf( 'Processing order %s|%s (Kustom ID: %s) with flow %s.', $order->get_id(), $order->get_order_number(), $kustom_order_id, get_class( $handler ) ) );
 

--- a/src/CheckoutFlow/CheckoutFlow.php
+++ b/src/CheckoutFlow/CheckoutFlow.php
@@ -24,9 +24,10 @@ abstract class CheckoutFlow {
 			$message = __( 'Invalid order ID.', 'klarna-checkout-for-woocommerce' );
 			throw new Exception( esc_html( $message ) );
 		}
-		$handler = self::get_handler();
+		$handler         = self::get_handler();
+		$kustom_order_id = $order->get_meta( '_wc_klarna_order_id', true ) ?: ( WC()->session ? WC()->session->get( 'kco_wc_order_id' ) : null ) ?? 'N/A';
 
-		\KCO_Logger::log( sprintf( 'Processing order %s|%s with flow %s.', $order->get_id(), $order->get_order_number(), get_class( $handler ) ) );
+		\KCO_Logger::log( sprintf( 'Processing order %s|%s (Kustom ID: %s) with flow %s.', $order->get_id(), $order->get_order_number(), $kustom_order_id, get_class( $handler ) ) );
 
 		return $handler->process( $order );
 	}


### PR DESCRIPTION
Regarding, the `CONTENT_LENGTH` change, we should calculate the raw string length directly since this header is sent from the client, it is spoofable.

https://app.clickup.com/t/869deb1q4