### PR TITLE
Shipping phone blocks

### DIFF
--- a/.changelogs/2026-06-04-shipping-phone-block-support
+++ b/.changelogs/2026-06-04-shipping-phone-block-support
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Corrected handling of the shipping phone field in Checkout Blocks to align with changes introduced in WooCommerce 10.8.0.

--- a/blocks/src/OrderValidation.php
+++ b/blocks/src/OrderValidation.php
@@ -294,6 +294,7 @@ class OrderValidation {
 				'state'      => $klarna_shipping_address['region'] ?? '',
 				'postcode'   => $klarna_shipping_address['postal_code'] ?? '',
 				'country'    => strtoupper( $klarna_shipping_address['country'] ?? '' ),
+				'phone'      => $klarna_shipping_address['phone'] ?? $klarna_billing_address['phone'] ?? '',
 			),
 		);
 

--- a/blocks/src/OrderValidation.php
+++ b/blocks/src/OrderValidation.php
@@ -294,7 +294,7 @@ class OrderValidation {
 				'state'      => $klarna_shipping_address['region'] ?? '',
 				'postcode'   => $klarna_shipping_address['postal_code'] ?? '',
 				'country'    => strtoupper( $klarna_shipping_address['country'] ?? '' ),
-				'phone'      => $klarna_shipping_address['phone'] ?? $klarna_billing_address['phone'] ?? '',
+				'phone'      => ! empty( $klarna_shipping_address['phone'] ) ? $klarna_shipping_address['phone'] : ( $klarna_billing_address['phone'] ?? '' ),
 			),
 		);
 


### PR DESCRIPTION
Include `phone` in the `shipping_address` data in order validation for the checkout block; fallback to billing address phone if not set.