### PR TITLE
Division by zero when calculating shipping cost

### DIFF
--- a/.changelogs/2026-06-10-refund-shipping-division-by-zero
+++ b/.changelogs/2026-06-10-refund-shipping-division-by-zero
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed a critical error that could occur when refunding an order with free (zero-cost) shipping.

--- a/src/OrderManagement/Request/Post/RequestPostRefund.php
+++ b/src/OrderManagement/Request/Post/RequestPostRefund.php
@@ -197,7 +197,7 @@ class RequestPostRefund extends RequestPost {
 
 					$order_shipping_total    = round( $order->get_shipping_total() * 100 );
 					$order_shipping_tax      = round( $order->get_shipping_tax() * 100 );
-					$order_shipping_tax_rate = 0 === $order_shipping_total ? 0 : round( ( $order_shipping_tax / $order_shipping_total ) * 10000 );
+					$order_shipping_tax_rate = empty( $order_shipping_total ) ? 0 : round( ( $order_shipping_tax / $order_shipping_total ) * 10000 );
 
 					$type                = 'shipping_fee';
 					$reference           = $shipping_item->get_method_id() . ':' . $shipping_item->get_instance_id();


### PR DESCRIPTION
- Fixed a critical error that could occur when refunding an order with free (zero-cost) shipping.

https://app.clickup.com/t/2423261/869dm6ynh