### PR TITLE
Fix wc defer block order creation issue

### DIFF
--- a/.changelogs/2026-06-29-fix-wc-deferred-draft-order-issue
+++ b/.changelogs/2026-06-29-fix-wc-deferred-draft-order-issue
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed an issue with WooCommerce version 10.9.x impacting the checkout block support. WooCommerce now only creates the order for the block checkout when the customer places the order, which caused an issue when placing the order.

--- a/blocks/src/OrderValidation.php
+++ b/blocks/src/OrderValidation.php
@@ -28,27 +28,30 @@ class OrderValidation {
 		}
 
 		$klarna_order         = self::get_klarna_order( $klarna_order_id );
-		$merchant_reference   = $klarna_order['merchant_reference2']; // Get the merchant reference from the klarna order.
 		$klarna_merchant_data = json_decode( $klarna_order['merchant_data'], true ) ?? array();
-		// If the merchant reference or klarna merchant data is empty, throw an exception.
-		if ( empty( $merchant_reference ) || empty( $klarna_merchant_data ) ) {
+		// The merchant data (which carries the cart token used to place the order) is always required.
+		if ( empty( $klarna_merchant_data ) ) {
 			throw new Exception( 'Could not validate the order, please try again.', 400 );
 		}
 
-		// Get the order from the merchant reference.
-		$order = self::get_wc_order( $merchant_reference );
+		// On WooCommerce 9.x there is no early draft order, so the reference may be empty and the order is created from
+		// the cart token below. When a reference exists, we validate and reuse that existing order instead.
+		$merchant_reference = $klarna_order['merchant_reference2'] ?? '';
+		$order              = ! empty( $merchant_reference ) ? self::get_wc_order( $merchant_reference ) : null;
 
-		self::validate_wc_order( $order );
+		if ( $order ) {
+			self::validate_wc_order( $order );
 
-		// Set the klarna order id in the order meta data.
-		$order->update_meta_data( '_wc_klarna_order_id', sanitize_key( $klarna_order_id ) );
+			// Set the klarna order id in the order meta data.
+			$order->update_meta_data( '_wc_klarna_order_id', sanitize_key( $klarna_order_id ) );
 
-		// Set the customers billing email from the klarna order.
-		$order->set_billing_email( $klarna_order['billing_address']['email'] ?? '' );
+			// Set the customers billing email from the klarna order.
+			$order->set_billing_email( $klarna_order['billing_address']['email'] ?? '' );
 
-		$order->save();
+			$order->save();
+		}
 
-		// Attempt to submit the order to WooCommerce using the store api.
+		// Submit the order via the store api. When no order exists yet it is created from the cart token.
 		$updated_order = self::submit_wc_order( $klarna_order, $order );
 
 		// Compare the order hashes to the once stored in the merchant data to ensure the order is valid.
@@ -227,13 +230,13 @@ class OrderValidation {
 	/**
 	 * Submit the WooCommerce order.
 	 *
-	 * @param array     $klarna_order The Klarna order.
-	 * @param \WC_Order $order The WooCommerce order.
+	 * @param array          $klarna_order The Klarna order.
+	 * @param \WC_Order|null $order The WooCommerce order, or null when it should be created from the cart token.
 	 *
 	 * @return \WC_Order The updated WooCommerce order after submission.
 	 * @throws Exception If the order could not be submitted.
 	 */
-	private static function submit_wc_order( $klarna_order, $order ) {
+	private static function submit_wc_order( $klarna_order, $order = null ) {
 		$settings                = get_option( 'woocommerce_kco_settings', array() );
 		$klarna_billing_address  = $klarna_order['billing_address'] ?? array();
 		$klarna_shipping_address = $klarna_order['shipping_address'] ?? array();
@@ -243,10 +246,10 @@ class OrderValidation {
 		$wc_nonce                = $klarna_merchant_data['wc_nonce'] ?? '';
 		$wp_logged_in_cookie     = $klarna_merchant_data['wp_logged_in_cookie'] ?? null;
 
-		$request_url = rest_url( 'wc/store/v1/checkout/' . $order->get_id() );
+		// Pay for the existing order, or post to the base endpoint so the Store API creates it from the cart token.
+		$request_url = $order ? rest_url( 'wc/store/v1/checkout/' . $order->get_id() ) : rest_url( 'wc/store/v1/checkout' );
 
 		$body = array(
-			'key'              => $order->get_order_key(),
 			'payment_method'   => 'kco',
 			'billing_email'    => $klarna_billing_address['email'] ?? '',
 			'payment_data'     => array(
@@ -297,6 +300,11 @@ class OrderValidation {
 				'phone'      => ! empty( $klarna_shipping_address['phone'] ) ? $klarna_shipping_address['phone'] : ( $klarna_billing_address['phone'] ?? '' ),
 			),
 		);
+
+		// The order key is required by the Store API to pay for an existing order, and omitted for the create flow.
+		if ( $order ) {
+			$body['key'] = $order->get_order_key();
+		}
 
 		// Set the billing company name if it exists.
 		if ( isset( $klarna_billing_address['organization_name'] ) ) {

--- a/blocks/src/OrderValidation.php
+++ b/blocks/src/OrderValidation.php
@@ -34,7 +34,7 @@ class OrderValidation {
 			throw new Exception( 'Could not validate the order, please try again.', 400 );
 		}
 
-		// On WooCommerce 9.x there is no early draft order, so the reference may be empty and the order is created from
+		// On WooCommerce 10.9.x there is no early draft order, so the reference may be empty and the order is created from
 		// the cart token below. When a reference exists, we validate and reuse that existing order instead.
 		$merchant_reference = $klarna_order['merchant_reference2'] ?? '';
 		$order              = ! empty( $merchant_reference ) ? self::get_wc_order( $merchant_reference ) : null;

--- a/blocks/src/Overrides.php
+++ b/blocks/src/Overrides.php
@@ -65,21 +65,35 @@ class Overrides {
 		$this->override_options( $args );
 		$this->set_merchant_data( $args );
 
+		// WooCommerce 10.9.x (PR #64155) defers draft order creation to the POST request, so this is null on a fresh
+		// session and the order is instead created from the cart token during validation.
+		$draft_order = $this->get_draft_order();
+
+		// Always set the merchant URLs so the validation callback is registered. get_urls() tolerates a null order id.
+		$this->override_merchant_urls( $args, $draft_order );
+
+		// When there is no draft order yet, the references are set later during process_payment.
+		if ( $draft_order ) {
+			$this->set_merchant_reference( $args, $draft_order );
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Get the Store API draft order from the session if it exists.
+	 *
+	 * @return \WC_Order|null The draft order, or null if none exists in the session.
+	 */
+	private function get_draft_order() {
 		$draft_order_id = WC()->session->get( 'store_api_draft_order', null );
 		if ( ! $draft_order_id ) {
-			return $args;
+			return null;
 		}
 
 		$draft_order = wc_get_order( $draft_order_id );
 
-		if ( ! $draft_order ) {
-			return $args;
-		}
-
-		$this->override_merchant_urls( $args, $draft_order );
-		$this->set_merchant_reference( $args, $draft_order );
-
-		return $args;
+		return $draft_order ?: null; // phpcs:ignore Universal.Operators.DisallowShortTernary.Found -- Safe to use here.
 	}
 
 	/**
@@ -99,13 +113,13 @@ class Overrides {
 	/**
 	 * Override the merchant URLs for the Klarna Checkout API.
 	 *
-	 * @param array     $args The request arguments.
-	 * @param \WC_Order $draft_order The WooCommerce order.
+	 * @param array          $args The request arguments.
+	 * @param \WC_Order|null $draft_order The WooCommerce order, or null if it does not exist yet.
 	 *
 	 * @return void
 	 */
-	private function override_merchant_urls( &$args, $draft_order ) {
-		$args['merchant_urls'] = KCO_WC()->merchant_urls->get_urls( $draft_order->get_id() );
+	private function override_merchant_urls( &$args, $draft_order = null ) {
+		$args['merchant_urls'] = KCO_WC()->merchant_urls->get_urls( $draft_order ? $draft_order->get_id() : null );
 		// Set the validation callback URL for the block checkout.
 		$args['merchant_urls']['validation'] = OrderController::get_validate_endpoint();
 	}


### PR DESCRIPTION
WooCommerce version 10.9.0 changed when the order was created when using the block checkout. Previously a draft order would have been created early on the checkout page, but now they defer it to happen when the customer places the order. This was done in PR [#64155](https://github.com/woocommerce/woocommerce/pull/64155) in WooCommerce.

This caused our logic for the checkout to no longer work as expected, preventing us to from processing the WooCommerce order correctly.

This change resolves that issue, while maintaining backwards compatibility to avoid issues with older versions.

Tested and confirmed working with WC Versions 10.9.1, 10.9.0, 10.8.1 and 10.7.0.