### PR TITLE
Fix "Undefined array key" warnings from unguarded gateway settings reads

### DIFF
--- a/.changelogs/2026-07-31-guard-settings-reads-request-options
+++ b/.changelogs/2026-07-31-guard-settings-reads-request-options
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed "Undefined array key" PHP warnings emitted on every checkout when a gateway setting has no stored value, e.g. on sites whose settings were seeded programmatically or that predate a setting being added.

--- a/classes/requests/helpers/class-kco-request-options.php
+++ b/classes/requests/helpers/class-kco-request-options.php
@@ -68,7 +68,7 @@ class KCO_Request_Options {
 	}
 
 	/**
-	 * Gets date of birth mandatory option.
+	 * Gets title mandatory option.
 	 *
 	 * @return bool
 	 */
@@ -101,7 +101,7 @@ class KCO_Request_Options {
 	}
 
 	/**
-	 * Gets date of birth mandatory option.
+	 * Gets national identification number validation mandatory option.
 	 *
 	 * @return bool
 	 */
@@ -186,17 +186,21 @@ class KCO_Request_Options {
 	/**
 	 * Gets shipping details note.
 	 *
-	 * @return string|bool The shipping details note, or false if the setting has no stored value.
+	 * @return string|false The shipping details note, or false if the setting has no stored value.
 	 */
 	private function get_shipping_details() {
-		return $this->settings['shipping_details'] ?? false;
+		if ( isset( $this->settings['shipping_details'] ) ) {
+			return $this->settings['shipping_details'];
+		}
+
+		return false;
 	}
 
 	/**
 	 * Checks option fields.
 	 *
 	 * @param string $field Field name.
-	 * @return array|bool
+	 * @return string|false The setting value, or false if the setting is unset or empty.
 	 */
 	private function check_option_field( $field ) {
 		if ( isset( $this->settings[ $field ] ) && '' !== $this->settings[ $field ] ) {

--- a/classes/requests/helpers/class-kco-request-options.php
+++ b/classes/requests/helpers/class-kco-request-options.php
@@ -73,7 +73,7 @@ class KCO_Request_Options {
 	 * @return bool
 	 */
 	private function get_title_mandatory() {
-		$title_mandatory = isset( $this->settings ) && 'yes' === $this->settings['title_mandatory'];
+		$title_mandatory = isset( $this->settings['title_mandatory'] ) && 'yes' === $this->settings['title_mandatory'];
 
 		return $title_mandatory;
 	}
@@ -84,7 +84,7 @@ class KCO_Request_Options {
 	 * @return bool
 	 */
 	private function get_allow_separate_shipping_address() {
-		$allow_separate_shipping = isset( $this->settings ) && 'yes' === $this->settings['allow_separate_shipping'];
+		$allow_separate_shipping = isset( $this->settings['allow_separate_shipping'] ) && 'yes' === $this->settings['allow_separate_shipping'];
 
 		return $allow_separate_shipping;
 	}
@@ -95,7 +95,7 @@ class KCO_Request_Options {
 	 * @return bool
 	 */
 	private function get_dob_mandatory() {
-		$dob_mandatory = isset( $this->settings ) && 'yes' === $this->settings['dob_mandatory'];
+		$dob_mandatory = isset( $this->settings['dob_mandatory'] ) && 'yes' === $this->settings['dob_mandatory'];
 
 		return $dob_mandatory;
 	}
@@ -106,7 +106,7 @@ class KCO_Request_Options {
 	 * @return bool
 	 */
 	private function get_nin_validation_mandatory() {
-		$nin_validation_mandatory = isset( $this->settings ) && isset( $this->settings['nin_validation_mandatory'] ) && 'yes' === $this->settings['nin_validation_mandatory'];
+		$nin_validation_mandatory = isset( $this->settings['nin_validation_mandatory'] ) && 'yes' === $this->settings['nin_validation_mandatory'];
 
 		return $nin_validation_mandatory;
 	}
@@ -186,14 +186,10 @@ class KCO_Request_Options {
 	/**
 	 * Gets shipping details note.
 	 *
-	 * @return bool
+	 * @return string|bool The shipping details note, or false if the setting has no stored value.
 	 */
 	private function get_shipping_details() {
-		if ( isset( $this->settings ) ) {
-			return $this->settings['shipping_details'];
-		}
-
-		return false;
+		return $this->settings['shipping_details'] ?? false;
 	}
 
 	/**
@@ -203,7 +199,7 @@ class KCO_Request_Options {
 	 * @return array|bool
 	 */
 	private function check_option_field( $field ) {
-		if ( isset( $this->settings ) && '' !== $this->settings[ $field ] ) {
+		if ( isset( $this->settings[ $field ] ) && '' !== $this->settings[ $field ] ) {
 			return $this->settings[ $field ];
 		}
 


### PR DESCRIPTION
## Problem

Every checkout emits a PHP warning:

```
Undefined array key "shipping_details"
classes/requests/helpers/class-kco-request-options.php:193
```

Observed on WooCommerce 10.9.4 / PHP 8.3.32 / KCO 2.20.7. It shows up as `last_error` on every single "Place Order flow" step in WooCommerce's own order-step debug log, which makes that log much harder to read when diagnosing real problems.

## Cause

`KCO_Request_Options` guards its settings reads with `isset( $this->settings )` — but `$this->settings` is a property assigned in the constructor, so `isset()` on it is always true (even when `get_option()` returns `false`). The key-level check was missing entirely, so any setting without a stored value triggers a warning.

The fields are all defined in `classes/class-kco-fields.php`, so a normally-configured site has them. A site whose gateway settings were seeded programmatically, or that predates a field being added, simply has no entry for the key.

## Fix

Check the key, not the property — matching the pattern already used elsewhere in the same file (`get_allowed_customer_types()`, `show_subtotal_detail()`). The reported line was one of five methods with the same defect:

| Method | Key(s) read unguarded |
|---|---|
| `get_shipping_details()` | `shipping_details` (the reported warning) |
| `check_option_field()` | all 7 colour/radius keys (`color_button`, `color_button_text`, `color_checkbox`, `color_checkbox_checkmark`, `color_header`, `color_link`, `radius_border`) |
| `get_title_mandatory()` | `title_mandatory` |
| `get_allow_separate_shipping_address()` | `allow_separate_shipping` |
| `get_dob_mandatory()` | `dob_mandatory` |

Also: `get_shipping_details()` now uses `?? false` and its `@return` docblock is corrected — it returns the note string, not a bool. The redundant double `isset` in `get_nin_validation_mandatory()` is dropped.

Behaviour is unchanged in every case, only the warning goes away — a missing key resolved to falsy before and still does.

## Note for a possible follow-up

Because behaviour is preserved, a site missing `title_mandatory` still sends `title_mandatory: false` to Kustom even though the field's default in `class-kco-fields.php` is `'yes'`. Aligning missing keys with their declared defaults would be a real behaviour change, so it is deliberately left out of this fix.

## Testing

- `composer lint:changes` passes clean
- `php -l` clean