### PR TITLE
Restored compatibility for the kco_check_if_needs_payment filter

### DIFF
--- a/.changelogs/2026-07-29-block-free-order-confirmation
+++ b/.changelogs/2026-07-29-block-free-order-confirmation
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Restored compatibility for the kco_check_if_needs_payment filter

--- a/blocks/src/OrderValidation.php
+++ b/blocks/src/OrderValidation.php
@@ -4,6 +4,7 @@ namespace Krokedil\KustomCheckout\Blocks;
 use Automattic\WooCommerce\StoreApi\SessionHandler;
 use Automattic\WooCommerce\StoreApi\Utilities\JsonWebToken;
 use Exception;
+use Krokedil\KustomCheckout\CheckoutFlow\EmbeddedBlockFlow;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -54,12 +55,59 @@ class OrderValidation {
 		// Submit the order via the store api. When no order exists yet it is created from the cart token.
 		$updated_order = self::submit_wc_order( $klarna_order, $order );
 
+		/*
+		 * When the order was created from the cart token, there was no draft order to store the Kustom order data on
+		 * above. Store it before validating the hashes below, so the order can always be found again from the Kustom
+		 * order ID, even if the validation fails.
+		 */
+		if ( empty( $order ) ) {
+			self::save_kustom_order_data( $updated_order, $klarna_order );
+		}
+
 		// Compare the order hashes to the once stored in the merchant data to ensure the order is valid.
 		self::validate_hash( $klarna_merchant_data['wc_cart_hash'], $updated_order->get_cart_hash() );
 		self::validate_hash( $klarna_merchant_data['wc_shipping_hash'], $updated_order->get_meta( '_shipping_hash' ) );
 		self::validate_hash( $klarna_merchant_data['wc_fees_hash'], $updated_order->get_meta( '_fees_hash' ) );
 		self::validate_hash( $klarna_merchant_data['wc_coupons_hash'], $updated_order->get_meta( '_coupons_hash' ) );
 		self::validate_hash( $klarna_merchant_data['wc_taxes_hash'], $updated_order->get_meta( '_taxes_hash' ) );
+	}
+
+	/**
+	 * Store the Kustom order data on an order that was created from the cart token.
+	 *
+	 * The Kustom order ID is required to be able to find the order again from the confirmation page and the push
+	 * callback, since neither of them can rely on the WooCommerce order key for these orders.
+	 *
+	 * WooCommerce skips the gateway for an order that does not need payment, such as an order where a coupon reduced the
+	 * total to zero, so none of the metadata the gateway normally stores exists for those. Store all of it here instead,
+	 * including the transaction ID, which the order received page needs to be able to print the Kustom confirmation
+	 * snippet.
+	 *
+	 * @param \WC_Order $order The WooCommerce order that was created from the cart token.
+	 * @param array     $klarna_order The Kustom order.
+	 *
+	 * @return void
+	 */
+	private static function save_kustom_order_data( $order, $klarna_order ) {
+		$klarna_order_id = sanitize_key( $klarna_order['order_id'] );
+
+		// The gateway always stores the checkout flow, so it did not run for this order when that is missing.
+		if ( empty( $order->get_meta( '_wc_klarna_checkout_flow' ) ) ) {
+			( new EmbeddedBlockFlow() )->save_order_metadata( $order, $klarna_order, 'embedded', false );
+
+			// WooCommerce completed the payment without a transaction ID, since the gateway never got to set one.
+			$order->set_transaction_id( $klarna_order_id );
+			$order->save();
+			return;
+		}
+
+		// The gateway already stored the Kustom order ID, so there is nothing left to do.
+		if ( $order->get_meta( '_wc_klarna_order_id' ) === $klarna_order_id ) {
+			return;
+		}
+
+		$order->update_meta_data( '_wc_klarna_order_id', $klarna_order_id );
+		$order->save();
 	}
 
 	/**

--- a/classes/class-kco-confirmation.php
+++ b/classes/class-kco-confirmation.php
@@ -93,9 +93,21 @@ class KCO_Confirmation {
 				 * handles orders that are not paid yet. Acknowledge the Kustom order here instead, so it does not depend
 				 * on the push callback arriving.
 				 */
-				KCO_Logger::log( $klarna_order_id . ': The order ' . $order->get_order_number() . ' was already marked as paid by WooCommerce. Acknowledge the Kustom order from the confirmation page.' );
-				KCO_WC()->api->acknowledge_klarna_order( $klarna_order_id );
-				KCO_WC()->api->set_merchant_reference( $klarna_order_id, $order->get_id() );
+				KCO_Logger::log( $klarna_order_id . ': The order ' . $order->get_order_number() . ' was already marked as paid by WooCommerce. Validate the Kustom order from the confirmation page before acknowledging it.' );
+
+				/*
+				 * Validate the order against the Kustom order before acknowledging it, the same way the confirmation and
+				 * push callback paths do. Acknowledging cannot be undone, so it must not happen for an order that does
+				 * not match. Leave it to the push callback whenever we cannot validate, and never let a failure here stop
+				 * the redirect below, since the customer would otherwise be left on the checkout page.
+				 */
+				$klarna_order = KCO_WC()->api->get_klarna_om_order( $klarna_order_id );
+				if ( is_wp_error( $klarna_order ) ) {
+					KCO_Logger::log( $klarna_order_id . ': Could not get the Kustom order from order management. Leaving the acknowledgement to the push callback.' );
+				} elseif ( kco_validate_order_total( $klarna_order, $order ) && kco_validate_order_content( $klarna_order, $order ) ) {
+					KCO_WC()->api->acknowledge_klarna_order( $klarna_order_id );
+					KCO_WC()->api->set_merchant_reference( $klarna_order_id, $order->get_id() );
+				}
 			}
 
 			kco_unset_sessions();

--- a/classes/class-kco-confirmation.php
+++ b/classes/class-kco-confirmation.php
@@ -57,8 +57,51 @@ class KCO_Confirmation {
 		$order_key       = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		// Return if we don't have our parameters set.
-		if ( empty( $kco_confirm ) || empty( $klarna_order_id ) || empty( $order_key ) ) {
+		if ( empty( $kco_confirm ) || empty( $klarna_order_id ) ) {
 			return;
+		}
+
+		/*
+		 * The confirmation URL is set before the WooCommerce order exists when the block checkout defers the order
+		 * creation to the point where the customer places the order. It therefore points at the checkout page, without
+		 * an order key, and we have to look the order up by the Kustom order ID instead. Redirect to the order received
+		 * page, since the confirmation URL cannot do it for us.
+		 */
+		if ( empty( $order_key ) ) {
+			/*
+			 * Without an order key we cannot verify the request against the order itself, so only trust the Kustom order
+			 * ID from the query string if it matches the one in the customer's own session. Otherwise anyone who knows
+			 * the Kustom order ID could be handed the order received URL, which contains the order key.
+			 */
+			if ( ! isset( WC()->session ) || WC()->session->get( 'kco_wc_order_id' ) !== $klarna_order_id ) {
+				KCO_Logger::log( $klarna_order_id . ': The Kustom order ID on the confirmation page does not match the one in the session. Cannot confirm the order without an order key.' );
+				return;
+			}
+
+			$order = kco_get_order_by_klarna_id( $klarna_order_id, '-2 days' );
+			if ( empty( $order ) ) {
+				KCO_Logger::log( $klarna_order_id . ': Could not find a WooCommerce order for the Kustom order ID on the confirmation page.' );
+				return;
+			}
+
+			if ( empty( $order->get_date_paid() ) ) {
+				KCO_Logger::log( $klarna_order_id . ': Confirm the Kustom order from the confirmation page, without an order key.' );
+				kco_confirm_klarna_order( $order->get_id(), $klarna_order_id );
+			} else {
+				/*
+				 * WooCommerce marks an order that does not need payment as paid itself, and kco_confirm_klarna_order only
+				 * handles orders that are not paid yet. Acknowledge the Kustom order here instead, so it does not depend
+				 * on the push callback arriving.
+				 */
+				KCO_Logger::log( $klarna_order_id . ': The order ' . $order->get_order_number() . ' was already marked as paid by WooCommerce. Acknowledge the Kustom order from the confirmation page.' );
+				KCO_WC()->api->acknowledge_klarna_order( $klarna_order_id );
+				KCO_WC()->api->set_merchant_reference( $klarna_order_id, $order->get_id() );
+			}
+
+			kco_unset_sessions();
+
+			wp_safe_redirect( $order->get_checkout_order_received_url() );
+			exit;
 		}
 
 		if ( ! empty( $order_id ) ) {


### PR DESCRIPTION
Restored compatibility for the kco_check_if_needs_payment filter: https://docs.krokedil.com/kustom-checkout-for-woocommerce/customization/hooks-action-filter/
https://app.clickup.com/t/2423261/869eaywb9