### PR TITLE
Develop klarna checkout comments

### DIFF
--- a/.changelogs/2026-08-03-rename-klarna-to-kustom-in-code-comments
+++ b/.changelogs/2026-08-03-rename-klarna-to-kustom-in-code-comments
@@ -1,0 +1,4 @@
+Type: Tweak
+Needs Documentation: no
+
+Updated code comments and docblocks to refer to Kustom instead of Klarna

--- a/blocks/src/Api/Controllers/OrderController.php
+++ b/blocks/src/Api/Controllers/OrderController.php
@@ -34,7 +34,7 @@ class OrderController extends Controller {
 	}
 
 	/**
-	 * Validate the order Kustom order.
+	 * Validate the Kustom order.
 	 *
 	 * @param \WP_REST_Request $request The request object.
 	 *

--- a/blocks/src/Api/Controllers/OrderController.php
+++ b/blocks/src/Api/Controllers/OrderController.php
@@ -34,7 +34,7 @@ class OrderController extends Controller {
 	}
 
 	/**
-	 * Validate the order Klarna order.
+	 * Validate the order Kustom order.
 	 *
 	 * @param \WP_REST_Request $request The request object.
 	 *
@@ -42,10 +42,10 @@ class OrderController extends Controller {
 	 */
 	public function validate( $request ) {
 		try {
-			// Get the Klarna order id from the request.
+			// Get the Kustom order id from the request.
 			$klarna_order_id = $request->get_param( 'id' );
 
-			// Validate the Klarna order.
+			// Validate the Kustom order.
 			OrderValidation::validate_kco_order( $klarna_order_id );
 
 			// Return a successful response with a 200 status code and empty body.

--- a/blocks/src/BlockExtension.php
+++ b/blocks/src/BlockExtension.php
@@ -141,7 +141,7 @@ class BlockExtension {
 	}
 
 	/**
-	 * Update the shipping address in WooCommerce on change from Klarna.
+	 * Update the shipping address in WooCommerce on change from Kustom.
 	 *
 	 * @param array $data The data from the API.
 	 *
@@ -167,28 +167,28 @@ class BlockExtension {
 	}
 
 	/**
-	 * Get the address data for the Kustom Checkout block. Also updates the Klarna order if needed.
+	 * Get the address data for the Kustom Checkout block. Also updates the Kustom order if needed.
 	 *
 	 * @return array
-	 * @throws Exception If we can't get the Klarna order.
+	 * @throws Exception If we can't get the Kustom order.
 	 */
 	public function get_address() {
 		$klarna_order_id = WC()->session->get( 'kco_wc_order_id' );
 
-		// Only run this if we have a Klarna order id.
+		// Only run this if we have a Kustom order id.
 		if ( ! $klarna_order_id ) {
 			return array();
 		}
 
-		// Maybe update the Klarna order.
+		// Maybe update the Kustom order.
 		$klarna_order = KCO_WC()->api->update_klarna_order( $klarna_order_id );
 
-		// If we did not get a Klarna order, get it instead.
+		// If we did not get a Kustom order, get it instead.
 		if ( ! $klarna_order ) {
 			$klarna_order = KCO_WC()->api->get_klarna_order( $klarna_order_id );
 		}
 
-		// If we still don't have a Klarna order, throw an exception.
+		// If we still don't have a Kustom order, throw an exception.
 		if ( ! $klarna_order ) {
 			throw new Exception( 'Could not get Klarna order' );
 		}

--- a/blocks/src/BlockExtension.php
+++ b/blocks/src/BlockExtension.php
@@ -167,7 +167,7 @@ class BlockExtension {
 	}
 
 	/**
-	 * Get the address data for the Klarna Checkout block. Also updates the Klarna order if needed.
+	 * Get the address data for the Kustom Checkout block. Also updates the Klarna order if needed.
 	 *
 	 * @return array
 	 * @throws Exception If we can't get the Klarna order.

--- a/blocks/src/Checkout/hooks/useKcoIframe.tsx
+++ b/blocks/src/Checkout/hooks/useKcoIframe.tsx
@@ -215,7 +215,7 @@ export const useKcoIframe = (
 	 * @return {void}
 	 */
 	const registerKCOEvents = useCallback(() => {
-		// Register listeners for the Klarna Checkout events.
+		// Register listeners for the Kustom Checkout events.
 		if ('function' !== typeof window._klarnaCheckout) {
 			return;
 		}

--- a/blocks/src/Checkout/index.tsx
+++ b/blocks/src/Checkout/index.tsx
@@ -17,7 +17,7 @@ import { getSetting } from '@woocommerce/settings';
 import { useKcoIframe } from './hooks/useKcoIframe';
 
 // Declare wc and _klarnaCheckout on the window object to avoid TypeScript errors when using them later.
-// _klarnaCheckout is added by the Klarna Checkout script, and wc is added by WooCommerce blocks.
+// _klarnaCheckout is added by the Kustom Checkout script, and wc is added by WooCommerce blocks.
 declare global {
 	interface Window {
 		_klarnaCheckout: any;

--- a/blocks/src/OrderValidation.php
+++ b/blocks/src/OrderValidation.php
@@ -15,9 +15,9 @@ defined( 'ABSPATH' ) || exit;
  */
 class OrderValidation {
 	/**
-	 * Validate the Klarna order.
+	 * Validate the Kustom order.
 	 *
-	 * @param string $klarna_order_id The Klarna order ID.
+	 * @param string $klarna_order_id The Kustom order ID.
 	 *
 	 * @return void
 	 * @throws Exception If the request is invalid or the order could not be verified.
@@ -42,10 +42,10 @@ class OrderValidation {
 		if ( $order ) {
 			self::validate_wc_order( $order );
 
-			// Set the klarna order id in the order meta data.
+			// Set the Kustom order id in the order meta data.
 			$order->update_meta_data( '_wc_klarna_order_id', sanitize_key( $klarna_order_id ) );
 
-			// Set the customers billing email from the klarna order.
+			// Set the customers billing email from the Kustom order.
 			$order->set_billing_email( $klarna_order['billing_address']['email'] ?? '' );
 
 			$order->save();
@@ -65,7 +65,7 @@ class OrderValidation {
 	/**
 	 * Validate the hashes to ensure the order is valid.
 	 *
-	 * @param string $klarna_hash The hash from Klarna.
+	 * @param string $klarna_hash The hash from Kustom.
 	 * @param string $wc_hash The hash from WooCommerce.
 	 *
 	 * @return void
@@ -80,7 +80,7 @@ class OrderValidation {
 	/**
 	 * Validate the hashes to ensure the order is valid.
 	 *
-	 * @param array          $klarna_order The Klarna order.
+	 * @param array          $klarna_order The Kustom order.
 	 * @param SessionHandler $session The WooCommerce session handler.
 	 *
 	 * @return void
@@ -121,12 +121,12 @@ class OrderValidation {
 	}
 
 	/**
-	 * Get the Klarna order and ensure that its valid.
+	 * Get the Kustom order and ensure that its valid.
 	 *
-	 * @param string $klarna_order_id The Klarna order ID.
+	 * @param string $klarna_order_id The Kustom order ID.
 	 *
 	 * @return array
-	 * @throws Exception If the request is invalid or the Klarna order could not be found.
+	 * @throws Exception If the request is invalid or the Kustom order could not be found.
 	 */
 	private static function get_klarna_order( $klarna_order_id ) {
 		$klarna_order = KCO_WC()->api->get_klarna_order( $klarna_order_id );
@@ -141,14 +141,14 @@ class OrderValidation {
 	/**
 	 * Validate the price to ensure the order is valid.
 	 *
-	 * @param int   $klarna_price The price from Klarna.
+	 * @param int   $klarna_price The price from Kustom.
 	 * @param float $wc_price The price from WooCommerce.
 	 *
 	 * @return void
 	 * @throws Exception If the prices do not match.
 	 */
 	private static function validate_price( $klarna_price, $wc_price ) {
-		// Divide the Klarna price by 100, to make it a floating point number.
+		// Divide the Kustom price by 100, to make it a floating point number.
 		$klarna_price = floatval( $klarna_price ) / 100;
 
 		$klarna_price = wc_format_decimal( $klarna_price, wc_get_price_decimals() );
@@ -162,7 +162,7 @@ class OrderValidation {
 	/**
 	 * Validate the order totals to ensure the order is valid.
 	 *
-	 * @param array     $klarna_order The Klarna order.
+	 * @param array     $klarna_order The Kustom order.
 	 * @param \WC_Order $order The WooCommerce order.
 	 *
 	 * @return void
@@ -199,13 +199,13 @@ class OrderValidation {
 	/**
 	 * Load the WooCommerce cart.
 	 *
-	 * @param array $klarna_order The Klarna order.
+	 * @param array $klarna_order The Kustom order.
 	 *
 	 * @return SessionHandler
 	 * @throws Exception If the cart could not be loaded.
 	 */
 	private static function load_wc_session( $klarna_order ) {
-		// Get the wc_cart_token from the klarna order merchant data.
+		// Get the wc_cart_token from the Kustom order merchant data.
 		$klarna_merchant_data = json_decode( $klarna_order['merchant_data'], true ) ?? array();
 		$wc_cart_token        = $klarna_merchant_data['wc_cart_token'] ?? '';
 
@@ -230,7 +230,7 @@ class OrderValidation {
 	/**
 	 * Submit the WooCommerce order.
 	 *
-	 * @param array          $klarna_order The Klarna order.
+	 * @param array          $klarna_order The Kustom order.
 	 * @param \WC_Order|null $order The WooCommerce order, or null when it should be created from the cart token.
 	 *
 	 * @return \WC_Order The updated WooCommerce order after submission.
@@ -316,7 +316,7 @@ class OrderValidation {
 			$body['shipping_address']['company'] = $klarna_shipping_address['organization_name'];
 		}
 
-		// If the klarna order is a recurring order.
+		// If the Kustom order is a recurring order.
 		if ( isset( $klarna_order['recurring'] ) ) {
 			$body['payment_data'][] = array(
 				'key'   => '_kco_recurring_order',

--- a/blocks/src/OrderValidation.php
+++ b/blocks/src/OrderValidation.php
@@ -121,7 +121,7 @@ class OrderValidation {
 	}
 
 	/**
-	 * Get the Kustom order and ensure that its valid.
+	 * Get the Kustom order and ensure that it's valid.
 	 *
 	 * @param string $klarna_order_id The Kustom order ID.
 	 *

--- a/blocks/src/Overrides.php
+++ b/blocks/src/Overrides.php
@@ -49,7 +49,7 @@ class Overrides {
 	}
 
 	/**
-	 * Override the request body for the Klarna Checkout API.
+	 * Override the request body for the Kustom Checkout API.
 	 *
 	 * @param array    $args The request arguments.
 	 * @param int|null $order_id The WooCommerce order ID.
@@ -97,7 +97,7 @@ class Overrides {
 	}
 
 	/**
-	 * Override the options for the Klarna Checkout API.
+	 * Override the options for the Kustom Checkout API.
 	 *
 	 * @param array $args The request arguments.
 	 *
@@ -111,7 +111,7 @@ class Overrides {
 	}
 
 	/**
-	 * Override the merchant URLs for the Klarna Checkout API.
+	 * Override the merchant URLs for the Kustom Checkout API.
 	 *
 	 * @param array          $args The request arguments.
 	 * @param \WC_Order|null $draft_order The WooCommerce order, or null if it does not exist yet.
@@ -125,7 +125,7 @@ class Overrides {
 	}
 
 	/**
-	 * Set the merchant reference for the Klarna Checkout API.
+	 * Set the merchant reference for the Kustom Checkout API.
 	 *
 	 * @param array     $args The request arguments.
 	 * @param \WC_Order $draft_order The WooCommerce order.
@@ -157,7 +157,7 @@ class Overrides {
 	}
 
 	/**
-	 * Set the merchant data for the Klarna Checkout API.
+	 * Set the merchant data for the Kustom Checkout API.
 	 *
 	 * @param array $args The request arguments.
 	 *

--- a/blocks/src/Overrides.php
+++ b/blocks/src/Overrides.php
@@ -143,7 +143,7 @@ class Overrides {
 	 * @return string
 	 */
 	private function create_cart_token() {
-		// Create a cart token for the Klarna order.
+		// Create a cart token for the Kustom order.
 		$cart_token = JsonWebToken::create(
 			array(
 				'user_id' => wc()->session->get_customer_id(),
@@ -166,7 +166,7 @@ class Overrides {
 	private function set_merchant_data( &$args ) {
 		$merchant_data = json_decode( $args['merchant_data'], true ) ?? array();
 
-		// Add the current cart hashes to the Klarna order merchant data object.
+		// Add the current cart hashes to the Kustom order merchant data object.
 		// @see https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/StoreApi/Utilities/CartController.php#L763-L769.
 		$cart_controller = new \Automattic\WooCommerce\StoreApi\Utilities\CartController();
 		$cart_hashes     = $cart_controller->get_cart_hashes();
@@ -185,7 +185,7 @@ class Overrides {
 
 		$args['merchant_data'] = wp_json_encode( $merchant_data );
 
-		// Set the cart token in the session for later use to prevent the update request to Klarna from triggering on each call.
+		// Set the cart token in the session for later use to prevent the update request to Kustom from triggering on each call.
 		WC()->session->set( 'kco_wc_cart_token', $cart_token );
 	}
 }

--- a/blocks/src/Schema/AddressSchema.php
+++ b/blocks/src/Schema/AddressSchema.php
@@ -6,7 +6,7 @@ namespace Krokedil\KustomCheckout\Blocks\Schema;
  */
 class AddressSchema {
 	/**
-	 * Returns the schema for the Klarna Checkout address data.
+	 * Returns the schema for the Kustom Checkout address data.
 	 *
 	 * @return array
 	 */

--- a/classes/class-kco-api.php
+++ b/classes/class-kco-api.php
@@ -45,7 +45,7 @@ class KCO_API {
 	/**
 	 * Gets a Kustom Checkout order
 	 *
-	 * @param string $klarna_order_id The Klarna Checkout order id.
+	 * @param string $klarna_order_id The Kustom Checkout order id.
 	 * @return array|false
 	 */
 	public function get_klarna_order( $klarna_order_id ) {

--- a/classes/class-kco-subscription.php
+++ b/classes/class-kco-subscription.php
@@ -345,7 +345,7 @@ class KCO_Subscription {
 	/**
 	 * Propagate subscription-specific meta from the parent order to its subscriptions.
 	 *
-	 * These values (Klarna environment, KSS shipping data) are written to the parent order during
+	 * These values (Kustom environment, KSS shipping data) are written to the parent order during
 	 * checkout, after the subscription has already been created. Saving them to the subscription
 	 * here ensures the Data Copier can copy them to renewal orders automatically.
 	 *

--- a/includes/kco-functions.php
+++ b/includes/kco-functions.php
@@ -949,9 +949,9 @@ function kco_update_wc_shipping( $data, $klarna_order = false ) {
 }
 
 /**
- * Maybe set the pickup point for the Klarna order if it exists.
+ * Maybe set the pickup point for the Kustom order if it exists.
  *
- * @param array $klarna_order The Klarna order data.
+ * @param array $klarna_order The Kustom order data.
  * @return void
  */
 function kco_maybe_set_selected_pickup_point( $klarna_order ) {

--- a/languages/klarna-checkout-for-woocommerce.pot
+++ b/languages/klarna-checkout-for-woocommerce.pot
@@ -763,7 +763,7 @@ msgstr ""
 
 #. translators: %s Klarna error message.
 #: ../src/OrderManagement/OrderManagement.php:523, ../src/OrderManagement/OrderManagement.php:563
-msgid "Could not refund Klarna order. %s."
+msgid "Could not refund Kustom order. %s."
 msgstr ""
 
 #: ../src/OrderManagement/OrderManagement.php:543

--- a/src/CheckoutFlow/CheckoutFlow.php
+++ b/src/CheckoutFlow/CheckoutFlow.php
@@ -145,7 +145,7 @@ abstract class CheckoutFlow {
 	}
 
 	/**
-	 * Get the Kustom order for a order number, or throw an error.
+	 * Get the Kustom order for an order number, or throw an error.
 	 *
 	 * @param string $klarna_order_id The Kustom order ID.
 	 *

--- a/src/CheckoutFlow/CheckoutFlow.php
+++ b/src/CheckoutFlow/CheckoutFlow.php
@@ -79,12 +79,12 @@ abstract class CheckoutFlow {
 	abstract public function process( $order );
 
 	/**
-	 * Get the Klarna order id for the order.
+	 * Get the Kustom order id for the order.
 	 *
 	 * @param \WC_Order $order The WooCommerce order.
 	 *
-	 * @return string|null The Klarna order id or null if not set.
-	 * @throws Exception If there is an error retrieving the Klarna order id.
+	 * @return string|null The Kustom order id or null if not set.
+	 * @throws Exception If there is an error retrieving the Kustom order id.
 	 */
 	public function get_klarna_order_id( $order ) {
 		// For the initial subscription, the Kustom order ID should always exist in the session.
@@ -111,7 +111,7 @@ abstract class CheckoutFlow {
 	/**
 	 * Log extra shipping debug information.
 	 *
-	 * @param string    $klarna_order_id The Klarna order ID.
+	 * @param string    $klarna_order_id The Kustom order ID.
 	 * @param \WC_Order $order The WooCommerce order.
 	 *
 	 * @return void
@@ -145,12 +145,12 @@ abstract class CheckoutFlow {
 	}
 
 	/**
-	 * Get the klarna order for a order number, or throw an error.
+	 * Get the Kustom order for a order number, or throw an error.
 	 *
-	 * @param string $klarna_order_id The Klarna order ID.
+	 * @param string $klarna_order_id The Kustom order ID.
 	 *
 	 * @return array
-	 * @throws Exception If the Klarna order is not found or if there is an error.
+	 * @throws Exception If the Kustom order is not found or if there is an error.
 	 */
 	public function get_klarna_order( $klarna_order_id ) {
 		$klarna_order = KCO_WC()->api->get_klarna_order( $klarna_order_id );
@@ -166,7 +166,7 @@ abstract class CheckoutFlow {
 	 * Save metadata to the order.
 	 *
 	 * @param \WC_Order $order The WooCommerce order.
-	 * @param array     $klarna_order The Klarna order data.
+	 * @param array     $klarna_order The Kustom order data.
 	 * @param string    $checkout_flow The checkout flow type (e.g., 'embedded', 'redirect').
 	 * @param bool      $save Whether to save the order metadata or not. Default is true.
 	 *

--- a/src/OrderManagement/MetaBox.php
+++ b/src/OrderManagement/MetaBox.php
@@ -126,7 +126,7 @@ class MetaBox extends OrderMetabox {
 	/**
 	 * Prints the standard content for the OM Metabox
 	 *
-	 * @param object $klarna_order The Klarna order object.
+	 * @param object $klarna_order The Kustom order object.
 	 * @return void
 	 */
 	public function print_standard_content( $klarna_order ) {
@@ -175,7 +175,7 @@ class MetaBox extends OrderMetabox {
 	 * Output the actions dropdown for the metabox.
 	 *
 	 * @param int    $order_id The ID of the order being considered.
-	 * @param object $klarna_order The Klarna order object associated with this order.
+	 * @param object $klarna_order The Kustom order object associated with this order.
 	 */
 	protected function output_actions_dropdown( $order_id, $klarna_order ) {
 		$settings = $this->order_management->settings->get_settings( $order_id );
@@ -324,7 +324,7 @@ class MetaBox extends OrderMetabox {
 	 * Determine if output associated with the Capture option is wanted.
 	 *
 	 * @param  int    $order_id The ID of the order being considered.
-	 * @param  object $klarna_order The Klarna order object associated with this order.
+	 * @param  object $klarna_order The Kustom order object associated with this order.
 	 * @param  array  $actions The enabled actions.
 	 *
 	 * @return bool Should Capture-related stuff be in the output?
@@ -338,7 +338,7 @@ class MetaBox extends OrderMetabox {
 			return false; // Already captured, can't capture again.
 		}
 		if ( in_array( $klarna_order->status, array( 'CAPTURED', 'PART_CAPTURED', 'CANCELLED' ), true ) ) {
-			return false; // Klarna says it's captured (in whole, or in part) at some point. Can't capture again.
+			return false; // Kustom says it's captured (in whole, or in part) at some point. Can't capture again.
 		}
 		if ( 'ACCEPTED' === $klarna_order->fraud_status ) {
 			return true;
@@ -351,7 +351,7 @@ class MetaBox extends OrderMetabox {
 	 * Determine if output associated with the Cancel option is wanted.
 	 *
 	 * @param  int    $order_id The ID of the order being considered.
-	 * @param  object $klarna_order The Klarna order object associated with this order.
+	 * @param  object $klarna_order The Kustom order object associated with this order.
 	 * @param  array  $actions The enabled actions.
 	 *
 	 * @return bool Should we add the cancel option to the output?
@@ -375,7 +375,7 @@ class MetaBox extends OrderMetabox {
 	 * Capture option for kco_order_actions action list.
 	 *
 	 * @param  int    $order_id The ID of the order being considered.
-	 * @param  object $klarna_order The Klarna order object associated with this order.
+	 * @param  object $klarna_order The Kustom order object associated with this order.
 	 * @param  array  $actions The enabled actions.
 	 * @return void
 	 */
@@ -389,7 +389,7 @@ class MetaBox extends OrderMetabox {
 	 * Output the tip fragment for the Capture option, if relevant.
 	 *
 	 * @param  int    $order_id The ID of the order being considered.
-	 * @param  object $klarna_order The Klarna order object associated with this order.
+	 * @param  object $klarna_order The Kustom order object associated with this order.
 	 * @param  array  $actions The enabled actions.
 	 * @return void
 	 */
@@ -403,7 +403,7 @@ class MetaBox extends OrderMetabox {
 	 * Cancel option for kco_order_actions action list.
 	 *
 	 * @param  int    $order_id The ID of the order being considered.
-	 * @param  object $klarna_order The Klarna order object associated with this order.
+	 * @param  object $klarna_order The Kustom order object associated with this order.
 	 * @param  array  $actions The enabled actions.
 	 * @return void
 	 */
@@ -417,7 +417,7 @@ class MetaBox extends OrderMetabox {
 	 * Output the tip fragment for the Cancel option, if relevant.
 	 *
 	 * @param  int    $order_id The ID of the order being considered.
-	 * @param  object $klarna_order The Klarna order object associated with this order.
+	 * @param  object $klarna_order The Kustom order object associated with this order.
 	 * @param  array  $actions The enabled actions.
 	 * @return void
 	 */
@@ -431,7 +431,7 @@ class MetaBox extends OrderMetabox {
 	 * Sync option for kco_order_actions action list.
 	 *
 	 * @param  int    $order_id The ID of the order being considered.
-	 * @param  object $klarna_order The Klarna order object associated with this order.
+	 * @param  object $klarna_order The Kustom order object associated with this order.
 	 * @param  array  $actions The enabled actions.
 	 * @return void
 	 */
@@ -445,7 +445,7 @@ class MetaBox extends OrderMetabox {
 	 * Output the tip fragment for the Sync option, if relevant.
 	 *
 	 * @param  int    $order_id The ID of the order being considered.
-	 * @param  object $klarna_order The Klarna order object associated with this order.
+	 * @param  object $klarna_order The Kustom order object associated with this order.
 	 * @param  array  $actions The enabled actions.
 	 * @return void
 	 */

--- a/src/OrderManagement/OrderLines.php
+++ b/src/OrderManagement/OrderLines.php
@@ -55,7 +55,7 @@ class OrderLines {
 	public $order;
 
 	/**
-	 * Klarna country used for creating this order.
+	 * Kustom country used for creating this order.
 	 *
 	 * @var string
 	 */
@@ -106,7 +106,7 @@ class OrderLines {
 	}
 
 	/**
-	 * Process WooCommerce order items to Klarna Payments order lines.
+	 * Process WooCommerce order items to Kustom order lines.
 	 */
 	public function process_order_line_items() {
 		$order = wc_get_order( $this->order_id );
@@ -158,7 +158,7 @@ class OrderLines {
 		 */
 		foreach ( $order->get_items( 'coupon' ) as $order_item ) {
 
-			/* Only smart coupons are added to the capture order lines, or if the merchant is a Klarna US merchant. */
+			/* Only smart coupons are added to the capture order lines, or if the merchant is a Kustom US merchant. */
 			$coupon = new \WC_Coupon( $order_item->get_name() );
 			if ( 'smart_coupon' === $coupon->get_discount_type() || 'US' === $this->klarna_country ) {
 				$this->order_lines[] = $this->process_order_item_coupon( $order_item, $order );

--- a/src/OrderManagement/OrderManagement.php
+++ b/src/OrderManagement/OrderManagement.php
@@ -520,7 +520,7 @@ class OrderManagement {
 
 		if ( is_wp_error( $klarna_order ) ) {
 			// translators: %s Kustom error message.
-			$order->add_order_note( \sprintf( __( 'Could not refund Klarna order. %s.', 'klarna-checkout-for-woocommerce' ), $klarna_order->get_error_message() ) );
+			$order->add_order_note( \sprintf( __( 'Could not refund Kustom order. %s.', 'klarna-checkout-for-woocommerce' ), $klarna_order->get_error_message() ) );
 			$order->save();
 
 			return new \WP_Error( 'object_error', 'Klarna order object is of type WP_Error.', $klarna_order );
@@ -560,7 +560,7 @@ class OrderManagement {
 		$response = $request->request();
 		if ( is_wp_error( $response ) ) {
 			// translators: %s Kustom error message.
-			$order->add_order_note( \sprintf( __( 'Could not refund Klarna order. %s.', 'klarna-checkout-for-woocommerce' ), $response->get_error_message() ) );
+			$order->add_order_note( \sprintf( __( 'Could not refund Kustom order. %s.', 'klarna-checkout-for-woocommerce' ), $response->get_error_message() ) );
 			$order->save();
 
 			return new \WP_Error( 'unknown_error', 'Response object is of type WP_Error.', $response );

--- a/src/OrderManagement/OrderManagement.php
+++ b/src/OrderManagement/OrderManagement.php
@@ -185,7 +185,7 @@ class OrderManagement {
 	}
 
 	/**
-	 * Add refunds support to Klarna Payments gateway.
+	 * Add refunds support to the Kustom Checkout gateway.
 	 *
 	 * @param array $features Supported features.
 	 *
@@ -198,7 +198,7 @@ class OrderManagement {
 	}
 
 	/**
-	 * Cancels a Klarna order.
+	 * Cancels a Kustom order.
 	 *
 	 * @param int  $order_id Order ID.
 	 * @param bool $action If this was triggered through an action or not.
@@ -231,7 +231,7 @@ class OrderManagement {
 				return new \WP_Error( 'rejected_in_pending_flow', 'Order is being rejected in pending flow.' );
 			}
 
-			// Retrieve Klarna order first.
+			// Retrieve Kustom order first.
 			$klarna_order = $this->retrieve_klarna_order( $order_id );
 
 			if ( is_wp_error( $klarna_order ) ) {
@@ -274,7 +274,7 @@ class OrderManagement {
 	}
 
 	/**
-	 * Updates Klarna order items.
+	 * Updates Kustom order items.
 	 *
 	 * @param int   $order_id Order ID.
 	 * @param array $items Order items.
@@ -333,7 +333,7 @@ class OrderManagement {
 				return new \WP_Error( 'not_allowed_status', 'Order is not in allowed status.' );
 			}
 
-			// Retrieve Klarna order first.
+			// Retrieve Kustom order first.
 			$klarna_order = $this->retrieve_klarna_order( $order_id );
 			if ( is_wp_error( $klarna_order ) ) {
 				$order->add_order_note( 'Klarna order could not be updated due to an error.' );
@@ -358,7 +358,7 @@ class OrderManagement {
 				} else {
 					$reason = $response->get_error_message();
 					if ( ! empty( $reason ) ) {
-						// translators: %s: error message from Klarna.
+						// translators: %s: error message from Kustom.
 						$order_note = sprintf( __( 'Could not update Klarna order lines: %s.', 'klarna-checkout-for-woocommerce' ), $reason );
 					} else {
 						$order_note = __( 'Could not update Klarna order lines. An unknown error occurred.', 'klarna-checkout-for-woocommerce' );
@@ -375,7 +375,7 @@ class OrderManagement {
 	}
 
 	/**
-	 * Captures a Klarna order.
+	 * Captures a Kustom order.
 	 *
 	 * @param int  $order_id Order ID.
 	 * @param bool $action If this was triggered by an action.
@@ -403,19 +403,19 @@ class OrderManagement {
 				return new \WP_Error( 'not_paid', 'Order has not been paid.' );
 			}
 
-			// Do nothing if Klarna order was already captured.
+			// Do nothing if Kustom order was already captured.
 			if ( $order->get_meta( '_wc_klarna_capture_id', true ) ) {
 				$order->add_order_note( 'Klarna order has already been captured.' );
 				$order->save();
 
 				return new \WP_Error( 'already_captured', 'Order has already been captured.' );
 			}
-			// Do nothing if we don't have Klarna order ID.
+			// Do nothing if we don't have Kustom order ID.
 			if ( ! $order->get_meta( '_wc_klarna_order_id', true ) && ! $order->get_transaction_id() ) {
 				$order->update_status( 'on-hold', 'Klarna order ID is missing, Klarna order could not be captured at this time.' );
 				return new \WP_Error( 'klarna_id_missing', 'Klarna order id is missing for order.' );
 			}
-			// Retrieve Klarna order.
+			// Retrieve Kustom order.
 			$klarna_order = $this->retrieve_klarna_order( $order_id );
 
 			if ( is_wp_error( $klarna_order ) ) {
@@ -427,21 +427,21 @@ class OrderManagement {
 				$order->update_status( 'on-hold', 'Klarna order is pending review and could not be captured at this time.' );
 				return new \WP_Error( 'pending_fraud_review', 'Order is pending fraud review and cannot be captured.' );
 			}
-			// Check if Klarna order has already been captured.
+			// Check if Kustom order has already been captured.
 			if ( in_array( $klarna_order->status, array( 'CAPTURED' ), true ) ) {
 				$order->add_order_note( 'Klarna order has already been captured on ' . $klarna_order->captures[0]->captured_at );
 				$order->update_meta_data( '_wc_klarna_capture_id', $klarna_order->captures[0]->capture_id );
 				$order->save();
 				return new \WP_Error( 'already_captured', 'Order has already been captured.' );
 			}
-			// Check if Klarna order has already been canceled.
+			// Check if Kustom order has already been canceled.
 			if ( 'CANCELLED' === $klarna_order->status ) {
 				$order->add_order_note( 'Klarna order failed to capture, the order has already been canceled' );
 				$order->save();
 
 				return new \WP_Error( 'klarna_order_cancelled', 'Order is cancelled. Capture failed.' );
 			}
-			// Only send capture request if Klarna order fraud status is accepted.
+			// Only send capture request if Kustom order fraud status is accepted.
 			if ( 'ACCEPTED' !== $klarna_order->fraud_status ) {
 				$order->add_order_note( 'Klarna order could not be captured at this time.' );
 				$order->save();
@@ -465,7 +465,7 @@ class OrderManagement {
 					return true;
 				}
 
-				/* The suggested approach by Klarna is to try again after some time. If that still fails, the merchant should inform the customer, and ask them to either "create a new subscription or add funds to their payment method if they wish to continue." */
+				/* The suggested approach by Kustom is to try again after some time. If that still fails, the merchant should inform the customer, and ask them to either "create a new subscription or add funds to their payment method if they wish to continue." */
 				if ( isset( $response->get_error_data()['code'] ) && 403 === $response->get_error_data()['code'] && 'PAYMENT_METHOD_FAILED' === $response->get_error_code() ) {
 					$order->update_status( 'on-hold', __( 'Klarna could not charge the customer. Please try again later. If that still fails, the customer may have to create a new subscription or add funds to their payment method if they wish to continue.', 'klarna-checkout-for-woocommerce' ) );
 					return new \WP_Error( 'capture_failed', 'Capture failed. Please try again later.' );
@@ -476,7 +476,7 @@ class OrderManagement {
 						$error_message = str_replace( '. Capture not possible.', sprintf( ': %s %s.', $klarna_order->remaining_authorized_amount / 100, $klarna_order->purchase_currency ), $error_message );
 					}
 
-					// translators: %s: Error message from Klarna.
+					// translators: %s: Error message from Kustom.
 					$order->update_status( 'on-hold', sprintf( __( 'Could not capture Klarna order. %s', 'klarna-checkout-for-woocommerce' ), $error_message ) );
 					return new \WP_Error( 'capture_failed', 'Capture failed.', $error_message );
 				}
@@ -485,7 +485,7 @@ class OrderManagement {
 	}
 
 	/**
-	 * Refund a Klarna order.
+	 * Refund a Kustom order.
 	 *
 	 * @param bool        $result Refund attempt result.
 	 * @param int         $order_id WooCommerce order ID.
@@ -507,7 +507,7 @@ class OrderManagement {
 			return new \WP_Error( 'order_sync_off', 'Order management is disabled' );
 		}
 
-		// Do nothing if Klarna order is not captured.
+		// Do nothing if Kustom order is not captured.
 		if ( ! $order->get_meta( '_wc_klarna_capture_id', true ) ) {
 			$order->add_order_note( __( 'Klarna order has not been captured and cannot be refunded.', 'klarna-checkout-for-woocommerce' ) );
 			$order->save();
@@ -515,18 +515,18 @@ class OrderManagement {
 			return new \WP_Error( 'not_captured', 'Order has not been captured and cannot be refunded.' );
 		}
 
-		// Retrieve Klarna order first.
+		// Retrieve Kustom order first.
 		$klarna_order = $this->retrieve_klarna_order( $order_id );
 
 		if ( is_wp_error( $klarna_order ) ) {
-			// translators: %s Klarna error message.
+			// translators: %s Kustom error message.
 			$order->add_order_note( \sprintf( __( 'Could not refund Klarna order. %s.', 'klarna-checkout-for-woocommerce' ), $klarna_order->get_error_message() ) );
 			$order->save();
 
 			return new \WP_Error( 'object_error', 'Klarna order object is of type WP_Error.', $klarna_order );
 		}
 
-		// We've checked for the metadata `_wc_klarna_capture_id`, now we check for the Klarna status.
+		// We've checked for the metadata `_wc_klarna_capture_id`, now we check for the Kustom status.
 		if ( ! in_array( $klarna_order->status, array( 'CAPTURED', 'PART_CAPTURED' ), true ) ) {
 			$order->add_order_note( __( 'Klarna order has not been captured and cannot be refunded.', 'klarna-checkout-for-woocommerce' ) );
 			$order->save();
@@ -559,7 +559,7 @@ class OrderManagement {
 
 		$response = $request->request();
 		if ( is_wp_error( $response ) ) {
-			// translators: %s Klarna error message.
+			// translators: %s Kustom error message.
 			$order->add_order_note( \sprintf( __( 'Could not refund Klarna order. %s.', 'klarna-checkout-for-woocommerce' ), $response->get_error_message() ) );
 			$order->save();
 
@@ -590,11 +590,11 @@ class OrderManagement {
 	}
 
 	/**
-	 * Retrieve a Klarna order.
+	 * Retrieve a Kustom order.
 	 *
 	 * @param int $order_id WooCommerce order ID.
 	 *
-	 * @return object $klarna_order Klarna Order.
+	 * @return object $klarna_order Kustom Order.
 	 */
 	public function retrieve_klarna_order( $order_id ) {
 		$request      = new RequestGetOrder(

--- a/src/OrderManagement/PendingOrders.php
+++ b/src/OrderManagement/PendingOrders.php
@@ -15,7 +15,7 @@ class PendingOrders {
 	/**
 	 * Notification listener for Pending orders.
 	 *
-	 * @param string $klarna_order_id Klarna order ID.
+	 * @param string $klarna_order_id Kustom order ID.
 	 *
 	 * @link https://developers.klarna.com/en/us/kco-v3/pending-orders
 	 */


### PR DESCRIPTION
Updated code comments and docblocks to refer to Kustom instead of Klarna, in line with the rebrand. Code identifiers, class names, translatable strings and references to Klarna's own products and plugins are unchanged, so this has no effect on plugin behaviour.
