### PR TITLE
Set shipping city in block checkout for shipping address changed event

### DIFF
--- a/.changelogs/2026-08-05-add-city-to-blocks-shipping-address-change
+++ b/.changelogs/2026-08-05-add-city-to-blocks-shipping-address-change
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Save the customer shipping city from Kustom alongside postcode and country during block-based address updates.

--- a/blocks/src/BlockExtension.php
+++ b/blocks/src/BlockExtension.php
@@ -153,6 +153,10 @@ class BlockExtension {
 			WC()->customer->set_shipping_postcode( $data['postal_code'] );
 		}
 
+		if ( isset( $data['city'] ) ) {
+			WC()->customer->set_shipping_city( $data['city'] );
+		}
+
 		if ( isset( $data['country'] ) ) {
 			WC()->customer->set_shipping_country( $data['country'] );
 		}


### PR DESCRIPTION
Handle the 'city' field in BlockExtension by calling WC()->customer->set_shipping_city($data['city']) when present. Ensures the customer's shipping city is saved along with postcode and country during block-based address updates.