### PR TITLE
Recover the checkout when the stored Kustom order has expired

### DIFF
--- a/.changelogs/2026-06-08-empty-body-checkout-reload-loop
+++ b/.changelogs/2026-06-08-empty-body-checkout-reload-loop
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed an issue where a returning customer could get stuck at the checkout when the order from their previous visit had expired. The checkout now discards the expired order and creates a new one instead of retrying it.

--- a/classes/class-kco-checkout.php
+++ b/classes/class-kco-checkout.php
@@ -111,26 +111,11 @@ class KCO_Checkout {
 			return;
 		}
 
-		// Requested directly rather than through the API wrapper, which reduces every failure to false. The error
-		// has to be readable here to tell "this order is gone" apart from a transient failure.
-		$response = ( new KCO_Request_Retrieve() )->request( $klarna_order_id );
-		if ( is_wp_error( $response ) || empty( $response ) ) {
+		$klarna_order = KCO_WC()->api->get_klarna_order( $klarna_order_id );
+		if ( ! $klarna_order ) {
 			KCO_Logger::log( "Klarna order could not be retrieved during update for ID: $klarna_order_id " );
-
-			if ( is_wp_error( $response ) ) {
-				kco_print_error_message( $response );
-
-				// Only discard the stored order when Kustom answered that it is gone. A timeout or a 5xx is transient,
-				// and dropping the ID there would orphan the order and create a new one on every hiccup.
-				$error_code = $response->get_error_code();
-				if ( 'received_empty_body' === $error_code || 404 === $error_code ) {
-					WC()->session->__unset( 'kco_wc_order_id' );
-				}
-			}
 			return;
 		}
-
-		$klarna_order = $response;
 
 		$updated_klarna_order = false;
 		if ( 'checkout_incomplete' === $klarna_order['status'] ) {

--- a/classes/class-kco-checkout.php
+++ b/classes/class-kco-checkout.php
@@ -111,13 +111,26 @@ class KCO_Checkout {
 			return;
 		}
 
-		$klarna_order = KCO_WC()->api->get_klarna_order( $klarna_order_id );
-		if ( ! $klarna_order ) {
+		// Requested directly rather than through the API wrapper, which reduces every failure to false. The error
+		// has to be readable here to tell "this order is gone" apart from a transient failure.
+		$response = ( new KCO_Request_Retrieve() )->request( $klarna_order_id );
+		if ( is_wp_error( $response ) || empty( $response ) ) {
 			KCO_Logger::log( "Klarna order could not be retrieved during update for ID: $klarna_order_id " );
-			// The stored order is gone (e.g. it expired). Clear it so this render creates a fresh order instead of retrying the dead ID.
-			WC()->session->__unset( 'kco_wc_order_id' );
+
+			if ( is_wp_error( $response ) ) {
+				kco_print_error_message( $response );
+
+				// Only discard the stored order when Kustom answered that it is gone. A timeout or a 5xx is transient,
+				// and dropping the ID there would orphan the order and create a new one on every hiccup.
+				$error_code = $response->get_error_code();
+				if ( 'received_empty_body' === $error_code || 404 === $error_code ) {
+					WC()->session->__unset( 'kco_wc_order_id' );
+				}
+			}
 			return;
 		}
+
+		$klarna_order = $response;
 
 		$updated_klarna_order = false;
 		if ( 'checkout_incomplete' === $klarna_order['status'] ) {

--- a/classes/class-kco-checkout.php
+++ b/classes/class-kco-checkout.php
@@ -114,6 +114,8 @@ class KCO_Checkout {
 		$klarna_order = KCO_WC()->api->get_klarna_order( $klarna_order_id );
 		if ( ! $klarna_order ) {
 			KCO_Logger::log( "Klarna order could not be retrieved during update for ID: $klarna_order_id " );
+			// The stored order is gone (e.g. it expired). Clear it so this render creates a fresh order instead of retrying the dead ID.
+			WC()->session->__unset( 'kco_wc_order_id' );
 			return;
 		}
 

--- a/classes/requests/class-kco-request.php
+++ b/classes/requests/class-kco-request.php
@@ -151,9 +151,15 @@ class KCO_Request {
 			$error_message = '';
 			// Get the error messages.
 			$errors = json_decode( $body, true );
-			if ( empty( $errors ) ) {
+			if ( '' === trim( $body ) ) {
 				// An expired order answers with an empty body. The checkout recovers by creating a new one, so keep this out of the customer's way.
+				// Only a genuinely empty body counts. A body we failed to decode is still a real error and has to reach the customer.
 				return new WP_Error( 'received_empty_body', "received empty body (HTTP {$code})", $data );
+			} elseif ( null === $errors ) {
+				// Not JSON at all, typically an HTML error page from something in front of Kustom. Keep the body out
+				// of the message so upstream markup is never rendered in the checkout, and log it instead.
+				KCO_Logger::log( "Unreadable error body (HTTP {$code}) from Kustom: " . substr( $body, 0, 500 ) . " URL: {$request_url}" );
+				return new WP_Error( $code, "the payment provider returned an unreadable error (HTTP {$code})", $data );
 			} elseif ( isset( $errors['error_messages'] ) && is_array( $errors['error_messages'] ) ) {
 				foreach ( $errors['error_messages'] as $error ) {
 					$error_message = "$error_message  $error";

--- a/classes/requests/class-kco-request.php
+++ b/classes/requests/class-kco-request.php
@@ -152,7 +152,8 @@ class KCO_Request {
 			// Get the error messages.
 			$errors = json_decode( $body, true );
 			if ( empty( $errors ) ) {
-				return new WP_Error( $code, 'received empty body', $data );
+				// An expired order answers with an empty body. The checkout recovers by creating a new one, so keep this out of the customer's way.
+				return new WP_Error( 'received_empty_body', "received empty body (HTTP {$code})", $data );
 			} elseif ( isset( $errors['error_messages'] ) && is_array( $errors['error_messages'] ) ) {
 				foreach ( $errors['error_messages'] as $error ) {
 					$error_message = "$error_message  $error";

--- a/classes/requests/class-kco-request.php
+++ b/classes/requests/class-kco-request.php
@@ -155,9 +155,11 @@ class KCO_Request {
 				// An expired order answers with an empty body. The checkout recovers by creating a new one, so keep this out of the customer's way.
 				// Only a genuinely empty body counts. A body we failed to decode is still a real error and has to reach the customer.
 				return new WP_Error( 'received_empty_body', "received empty body (HTTP {$code})", $data );
-			} elseif ( null === $errors ) {
+			} elseif ( JSON_ERROR_NONE !== json_last_error() ) {
 				// Not JSON at all, typically an HTML error page from something in front of Kustom. Keep the body out
 				// of the message so upstream markup is never rendered in the checkout, and log it instead.
+				// Asks json_last_error() rather than testing $errors for null, since a body of literal null decodes to
+				// null without being a decode failure.
 				KCO_Logger::log( "Unreadable error body (HTTP {$code}) from Kustom: " . substr( $body, 0, 500 ) . " URL: {$request_url}" );
 				return new WP_Error( $code, "the payment provider returned an unreadable error (HTTP {$code})", $data );
 			} elseif ( isset( $errors['error_messages'] ) && is_array( $errors['error_messages'] ) ) {

--- a/classes/requests/class-kco-request.php
+++ b/classes/requests/class-kco-request.php
@@ -156,10 +156,6 @@ class KCO_Request {
 				// Only a genuinely empty body counts. A body we failed to decode is still a real error and has to reach the customer.
 				return new WP_Error( 'received_empty_body', "received empty body (HTTP {$code})", $data );
 			} elseif ( JSON_ERROR_NONE !== json_last_error() ) {
-				// Not JSON at all, typically an HTML error page from something in front of Kustom. Keep the body out
-				// of the message so upstream markup is never rendered in the checkout, and log it instead.
-				// Asks json_last_error() rather than testing $errors for null, since a body of literal null decodes to
-				// null without being a decode failure.
 				KCO_Logger::log( "Unreadable error body (HTTP {$code}) from Kustom: " . substr( $body, 0, 500 ) . " URL: {$request_url}" );
 				return new WP_Error( $code, "the payment provider returned an unreadable error (HTTP {$code})", $data );
 			} elseif ( isset( $errors['error_messages'] ) && is_array( $errors['error_messages'] ) ) {

--- a/includes/kco-functions.php
+++ b/includes/kco-functions.php
@@ -26,6 +26,8 @@ function kco_create_or_update_order() {
 	WC()->cart->calculate_totals();
 	if ( WC()->session->get( 'kco_wc_order_id' ) ) { // Check if we have an order id.
 		// Try to update the order, if it fails try to create new order.
+		// This is also how an order that expired at Kustom recovers: the update answers 404 with an empty body and
+		// fails, and the create below replaces the stale session id. Keep that fallback intact.
 		$klarna_order = KCO_WC()->api->update_klarna_order( WC()->session->get( 'kco_wc_order_id' ), null, true );
 		if ( ! $klarna_order ) {
 			// If update order failed try to create new order.

--- a/includes/kco-functions.php
+++ b/includes/kco-functions.php
@@ -26,8 +26,6 @@ function kco_create_or_update_order() {
 	WC()->cart->calculate_totals();
 	if ( WC()->session->get( 'kco_wc_order_id' ) ) { // Check if we have an order id.
 		// Try to update the order, if it fails try to create new order.
-		// This is also how an order that expired at Kustom recovers: the update answers 404 with an empty body and
-		// fails, and the create below replaces the stale session id. Keep that fallback intact.
 		$klarna_order = KCO_WC()->api->update_klarna_order( WC()->session->get( 'kco_wc_order_id' ), null, true );
 		if ( ! $klarna_order ) {
 			// If update order failed try to create new order.

--- a/includes/kco-functions.php
+++ b/includes/kco-functions.php
@@ -566,6 +566,11 @@ function is_kco_confirmation() {
  * @return void
  */
 function kco_print_error_message( $wp_error ) {
+	// The checkout recovers from an empty body on its own by creating a new order, so don't alarm the customer.
+	if ( 'received_empty_body' === $wp_error->get_error_code() ) {
+		return;
+	}
+
 	if ( is_ajax() ) {
 		wc_add_notice( $wp_error->get_error_message(), 'error' );
 	} else {


### PR DESCRIPTION
A customer who created a Kustom order and returned about two days later kept their order id in the WooCommerce session, but Kustom had already expired the order. The GET and the update both answered 404 with an empty body, which was printed to the customer as "received empty body" and left them stuck at the checkout until they reloaded the page by hand.

Clear the stored order id when the retrieve fails, so the same render falls through to creating a fresh order, and give the empty body its own error code so it is no longer printed. The checkout recovers on its own, so there is nothing for the customer to act on.

https://app.clickup.com/t/2423261/869anq6yd