### PR TITLE
Fix "Undefined array key" warnings for credentials

### DIFF
--- a/.changelogs/2026-08-05-fix-credentials-warnings
+++ b/.changelogs/2026-08-05-fix-credentials-warnings
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed "Undefined array key" warnings that could appear when retrieving stored credentials.

--- a/classes/class-kco-credentials.php
+++ b/classes/class-kco-credentials.php
@@ -44,9 +44,10 @@ class KCO_Credentials {
 			$country_string = 'eu';
 		}
 
-		$test_string   = 'yes' === $this->settings['testmode'] ? 'test_' : '';
-		$merchant_id   = $this->settings[ $test_string . 'merchant_id_' . $country_string ];
-		$shared_secret = $this->settings[ $test_string . 'shared_secret_' . $country_string ];
+		$testmode      = $this->settings['testmode'] ?? 'no';
+		$test_string   = 'yes' === $testmode ? 'test_' : '';
+		$merchant_id   = $this->settings[ $test_string . 'merchant_id_' . $country_string ] ?? '';
+		$shared_secret = $this->settings[ $test_string . 'shared_secret_' . $country_string ] ?? '';
 
 		// Merchant id and/or shared secret not found for matching country.
 		if ( '' === $merchant_id || '' === $shared_secret ) {
@@ -54,10 +55,10 @@ class KCO_Credentials {
 		}
 
 		$credentials = array(
-			'merchant_id'   => $this->settings[ $test_string . 'merchant_id_' . $country_string ],
-			'shared_secret' => htmlspecialchars_decode( $this->settings[ $test_string . 'shared_secret_' . $country_string ], ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
+			'merchant_id'   => $merchant_id,
+			'shared_secret' => htmlspecialchars_decode( $shared_secret, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401 ),
 		);
 
-		return apply_filters( 'kco_wc_credentials_from_session', $credentials, $this->settings['testmode'] );
+		return apply_filters( 'kco_wc_credentials_from_session', $credentials, $testmode );
 	}
 }


### PR DESCRIPTION
Fixes some "Undefined array key" warnings that could appear when retrieving stored credentials:

`[06-May-2026 10:12:43 UTC] PHP Warning:  Undefined array key "testmode" in /wordpress/wp-content/plugins/klarna-checkout-for-woocommerce/classes/class-kco-credentials.php on line 47
[06-May-2026 10:12:43 UTC] PHP Warning:  Undefined array key "merchant_id_us" in /wordpress/wp-content/plugins/klarna-checkout-for-woocommerce/classes/class-kco-credentials.php on line 48
[06-May-2026 10:12:43 UTC] PHP Warning:  Undefined array key "shared_secret_us" in /wordpress/wp-content/plugins/klarna-checkout-for-woocommerce/classes/class-kco-credentials.php on line 49...`