### PR TITLE
Fix OM conflict

### DIFF
--- a/.changelogs/2026-08-12-fix-om-conflict
+++ b/.changelogs/2026-08-12-fix-om-conflict
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Resolved a compatibility conflict with the "Klarna for WooCommerce" plugin that could cause WooCommerce refund processing to fail when both plugins were active.

--- a/src/OrderManagement/OrderManagement.php
+++ b/src/OrderManagement/OrderManagement.php
@@ -497,9 +497,9 @@ class OrderManagement {
 	public function refund_klarna_order( $result, $order_id, $amount = null, $reason = '' ) {
 		$order = wc_get_order( $order_id );
 
-		// If the order was not paid using the plugin that instanced this class, bail.
+		// If the order was not paid using Kustom Checkout, return the original result.
 		if ( 'kco' !== $order->get_payment_method() ) {
-			return;
+			return $result;
 		}
 
 		// The merchant has disconnected the order from the order manager.


### PR DESCRIPTION
Resolves a compatibility conflict with the "Klarna for WooCommerce" plugin that could cause WooCommerce refund processing to fail when both plugins were active.