### PR TITLE
Make sure that the product exists

### DIFF
--- a/.changelogs/2026-08-17-guard-deleted-product-order-lines
+++ b/.changelogs/2026-08-17-guard-deleted-product-order-lines
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed a fatal error that could occur when sending order lines to Kustom for an order containing a product that has since been deleted from the store.

--- a/classes/requests/helpers/class-kco-request-order.php
+++ b/classes/requests/helpers/class-kco-request-order.php
@@ -93,7 +93,7 @@ class KCO_Request_Order {
 		);
 
 		$settings = get_option( 'woocommerce_kco_settings', array() );
-		if ( isset( $settings['send_product_urls'] ) && 'yes' === $settings['send_product_urls'] ) {
+		if ( ! empty( $product ) && isset( $settings['send_product_urls'] ) && 'yes' === $settings['send_product_urls'] ) {
 
 			$image_url = wp_get_attachment_image_url( $product->get_image_id(), 'shop_single', false );
 			if ( $image_url ) {


### PR DESCRIPTION
Fixes a fatal error that can occur when sending order lines to Kustom for an order containing a product that has since been deleted from the store.