### PR TITLE
Add the `kco_wc_order_line_include_item_meta` filter

### DIFF
--- a/.changelogs/2026-08-19-order-line-item-meta-filter
+++ b/.changelogs/2026-08-19-order-line-item-meta-filter
@@ -1,0 +1,4 @@
+Type: Add
+Needs Documentation: yes
+
+Added the `kco_wc_order_line_include_item_meta` filter, which appends a cart or order item's WooCommerce meta data (variation attributes and product add-ons) to the order line name sent to Kustom. Disabled by default.

--- a/classes/requests/helpers/class-kco-request-cart.php
+++ b/classes/requests/helpers/class-kco-request-cart.php
@@ -392,9 +392,34 @@ class KCO_Request_Cart {
 	 * @return string $item_name Cart item name.
 	 */
 	public function get_item_name( $cart_item ) {
-		$item_name = substr( $cart_item['data']->get_name(), 0, 254 );
+		$item_name = $cart_item['data']->get_name();
 
-		return wp_strip_all_tags( $item_name );
+		/**
+		 * Filter whether to append the item's WooCommerce meta data to the order line name.
+		 *
+		 * @param bool                     $include Whether to append the item meta data. Default false.
+		 * @param array|WC_Order_Item      $item    The cart item, or the order item in the 'order' context.
+		 * @param string                   $context Either 'cart' or 'order'.
+		 */
+		if ( apply_filters( 'kco_wc_order_line_include_item_meta', false, $cart_item, 'cart' ) ) {
+			$item_meta = array();
+
+			// WooCommerce returns the meta data as one "key: value" per line.
+			foreach ( preg_split( '/\R/', wc_get_formatted_cart_item_data( $cart_item, true ) ) as $line ) {
+				$pair = explode( ': ', $line, 2 );
+				$meta = isset( $pair[1] ) ? kco_format_order_line_meta( $pair[0], $pair[1] ) : kco_clean_order_line_name( $line );
+
+				if ( '' !== $meta ) {
+					$item_meta[] = $meta;
+				}
+			}
+
+			if ( ! empty( $item_meta ) ) {
+				$item_name .= ' (' . implode( ', ', $item_meta ) . ')';
+			}
+		}
+
+		return substr( kco_clean_order_line_name( $item_name ), 0, 254 );
 	}
 
 	/**

--- a/includes/kco-functions.php
+++ b/includes/kco-functions.php
@@ -1089,3 +1089,41 @@ function kco_cart_needs_payment() {
 	// A subscription in the cart always needs payment.
 	return $needs_payment || KCO_Subscription::cart_has_subscription();
 }
+
+/**
+ * Cleans a string for use in an order line name.
+ *
+ * @param string $text The text to clean.
+ * @return string
+ */
+function kco_clean_order_line_name( $text ) {
+	$text = html_entity_decode( wp_strip_all_tags( (string) $text ), ENT_QUOTES, 'UTF-8' );
+
+	// Returns null if the text is not valid UTF-8, in which case leave the text as it is.
+	$normalized = preg_replace( '/[\s\x{00A0}]+/u', ' ', $text );
+
+	return trim( null === $normalized ? $text : $normalized );
+}
+
+/**
+ * Formats an item meta data key and value pair for use in an order line name.
+ *
+ * @param string $key The meta data display key.
+ * @param string $value The meta data display value.
+ * @return string
+ */
+function kco_format_order_line_meta( $key, $value ) {
+	$key   = rtrim( kco_clean_order_line_name( $key ), ':' );
+	$value = kco_clean_order_line_name( $value );
+
+	if ( '' === $value ) {
+		return $key;
+	}
+
+	// Some plugins repeat the label in the value, which would otherwise read as "Gift wrap: Gift wrap".
+	if ( '' === $key || 0 === stripos( $value, $key ) ) {
+		return $value;
+	}
+
+	return "$key: $value";
+}

--- a/src/OrderManagement/OrderLines.php
+++ b/src/OrderManagement/OrderLines.php
@@ -394,7 +394,30 @@ class OrderLines {
 		// Matching the item name from KCO order.
 		$order_line_item_name = $order_line_item->get_name();
 
-		return (string) wp_strip_all_tags( $order_line_item_name );
+		/**
+		 * Filter whether to append the item's WooCommerce meta data to the order line name.
+		 *
+		 * @param bool                $include Whether to append the item meta data. Default false.
+		 * @param array|WC_Order_Item $item    The order item, or the cart item in the 'cart' context.
+		 * @param string              $context Either 'cart' or 'order'.
+		 */
+		if ( $order_line_item instanceof \WC_Order_Item_Product
+			&& apply_filters( 'kco_wc_order_line_include_item_meta', false, $order_line_item, 'order' ) ) {
+			$item_meta = array();
+			foreach ( $order_line_item->get_formatted_meta_data() as $meta ) {
+				$formatted = kco_format_order_line_meta( $meta->display_key, $meta->display_value );
+
+				if ( '' !== $formatted ) {
+					$item_meta[] = $formatted;
+				}
+			}
+
+			if ( ! empty( $item_meta ) ) {
+				$order_line_item_name .= ' (' . implode( ', ', $item_meta ) . ')';
+			}
+		}
+
+		return substr( kco_clean_order_line_name( $order_line_item_name ), 0, 254 );
 	}
 
 	/**


### PR DESCRIPTION
Adds the `kco_wc_order_line_include_item_meta` filter, which appends a cart or order item's WooCommerce meta data (variation attributes and product add-ons) to the order line name sent to Kustom.