### PR TITLE
Guard checkout block requests outside checkout page

### DIFF
--- a/blocks/src/Checkout/CheckoutBlock.php
+++ b/blocks/src/Checkout/CheckoutBlock.php
@@ -110,7 +110,7 @@ class CheckoutBlock extends AbstractPaymentMethodType {
 	 */
 	private function get_data() {
 		$icon_url = plugins_url( 'assets/img/kustom_logo_primary.png', KCO_WC_MAIN_FILE );
-		if ( $this->is_admin() ) {
+		if ( $this->is_admin() || WC()->cart->is_empty() || ! is_checkout() ) {
 			return array(
 				'title'            => $this->get_setting( 'title' ),
 				'description'      => $this->get_setting( 'description' ),


### PR DESCRIPTION
Extend the early-return path in `CheckoutBlock::get_data()` to also skip checkout-specific processing when the cart is empty or the current page is not checkout. This avoids running checkout-dependent logic in non-checkout contexts while still returning basic payment method settings.