### PR TITLE
Create session issue

### DIFF
--- a/.changelogs/2026-08-20-create-session-issue
+++ b/.changelogs/2026-08-20-create-session-issue
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed an issue where the cart block triggered excessive calls to Kustom on cart page visits.

--- a/blocks/src/Checkout/CheckoutBlock.php
+++ b/blocks/src/Checkout/CheckoutBlock.php
@@ -110,7 +110,7 @@ class CheckoutBlock extends AbstractPaymentMethodType {
 	 */
 	private function get_data() {
 		$icon_url = plugins_url( 'assets/img/kustom_logo_primary.png', KCO_WC_MAIN_FILE );
-		if ( $this->is_admin() ) {
+		if ( $this->is_admin() || WC()->cart->is_empty() || ! is_checkout() ) {
 			return array(
 				'title'            => $this->get_setting( 'title' ),
 				'description'      => $this->get_setting( 'description' ),


### PR DESCRIPTION
"Extend the early-return path in CheckoutBlock::get_data() to also skip checkout-specific processing when the cart is empty or the current page is not checkout. This avoids running checkout-dependent logic in non-checkout contexts while still returning basic payment method settings."

First created as a hotfix: https://github.com/krokedil/klarna-checkout-for-woocommerce/pull/801