### PR TITLE
Redact auth headers from the log data

### DIFF
--- a/.changelogs/2026-08-21-redact-log-auth-header
+++ b/.changelogs/2026-08-21-redact-log-auth-header
@@ -1,0 +1,4 @@
+Type: Tweak
+Needs Documentation: no
+
+The authorization header is now redacted from the log created for requests when logging is enabled.

--- a/classes/class-kco-logger.php
+++ b/classes/class-kco-logger.php
@@ -79,6 +79,16 @@ class KCO_Logger {
 				$request_args['body'] = wp_json_encode( $request_body );
 			}
 		}
+
+		// Redact the authorization header if it is present.
+		foreach ( $request_args['headers'] as $header => $value ) {
+			if ( 'authorization' === strtolower( $header ) ) {
+				// If it is longer than 15 char., it most likely has a token. This is an assumption that is safe even if it is wrong.
+				$request_args['headers'][ $header ] = strlen( $value ) > 15 ? '[REDACTED]' : '[MISSING]';
+				break;
+			}
+		}
+
 		return array(
 			'id'             => $klarna_order_id,
 			'type'           => $method,


### PR DESCRIPTION
This pull request changes the logging functionality by ensuring that authorization headers are not logged.

**Logging Changes:**

* In `class-kco-logger.php`, the `format_log` method now redacts the `Authorization` header in `$request_args['headers']` before logging. If the header value is longer than 15 characters (likely a token), it is replaced with `[REDACTED]`; otherwise, it is replaced with `[MISSING]`.