### PR TITLE
Run our refund handler last on wc_klarna_checkout_process_refund

### DIFF
--- a/.changelogs/2026-08-21-fix-refund-om-conflict
+++ b/.changelogs/2026-08-21-fix-refund-om-conflict
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed an issue where a Kustom refund could be registered with Kustom but then discarded by WooCommerce when another Klarna plugin also handled order management.

--- a/src/OrderManagement/OrderManagement.php
+++ b/src/OrderManagement/OrderManagement.php
@@ -117,7 +117,7 @@ class OrderManagement {
 		// Update an order.
 		add_action( 'woocommerce_saved_order_items', array( $this, 'update_klarna_order_items' ), 10, 2 );
 
-		// Refund an order. Runs last so another plugin on this filter can't discard our result.
+		// Refund an order. Runs after lower-priority callbacks so they can't discard our result.
 		add_filter( 'wc_klarna_checkout_process_refund', array( $this, 'refund_klarna_order' ), PHP_INT_MAX, 4 );
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin' ) );

--- a/src/OrderManagement/OrderManagement.php
+++ b/src/OrderManagement/OrderManagement.php
@@ -117,8 +117,8 @@ class OrderManagement {
 		// Update an order.
 		add_action( 'woocommerce_saved_order_items', array( $this, 'update_klarna_order_items' ), 10, 2 );
 
-		// Refund an order.
-		add_filter( 'wc_klarna_checkout_process_refund', array( $this, 'refund_klarna_order' ), 10, 4 );
+		// Refund an order. Runs last so another plugin on this filter can't discard our result.
+		add_filter( 'wc_klarna_checkout_process_refund', array( $this, 'refund_klarna_order' ), PHP_INT_MAX, 4 );
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin' ) );
 	}


### PR DESCRIPTION
## Problem

On a store running Kustom Checkout alongside another Klarna plugin that also handles order management, every Kustom refund succeeded at Kustom but was then deleted locally by WooCommerce. The order was never marked refunded, no local refund record survived, and the admin saw the generic *"An error occurred while attempting to create the refund using the payment gateway API."*

## Root cause

`KCO_Gateway::process_refund()` returns `apply_filters( 'wc_klarna_checkout_process_refund', false, … )`, and `apply_filters` returns the **last** callback's value.

The other plugin registered its own order management on this same filter at priority 10 and, for a `kco` order, bailed with a bare `return;` → `null`. Our handler was also at priority 10, and since Kustom loads first alphabetically, theirs ran last and overwrote our `true`.

`wc_refund_payment()` then checks the result with a plain falsy test (`if ( ! $result )`, `wc-order-functions.php:786`), so `null` is indistinguishable from an explicit refusal. `wc_create_refund()` force-deletes the refund record it had just created — after the money had already moved at Kustom.

## Fix

Register our refund handler at `PHP_INT_MAX` so it runs last and its result is the one WooCommerce reads.

Our handler recomputes its own verdict from the Kustom API for every `kco` order and ignores the incoming `$result`, so running last is sufficient. For non-`kco` orders it returns `$result` untouched, so it stays a transparent pass-through for other gateways.

Priority affects only *ordering*, not whether callbacks run — every handler still executes exactly as before, so this introduces no new API calls and no behaviour change for any other plugin.

## Verification

Tested against a local WooCommerce store with the real conflicting plugin installed from its wordpress.org release alongside Kustom Checkout, plus a `pre_http_request` sniffer capturing every outgoing HTTP request.

| Priority | Filter order | Refund outcome | Outgoing requests |
| --- | --- | --- | --- |
| `10` (before) | Kustom → other plugin | **deleted locally** | 1 POST to Kustom `/refunds` — succeeded |
| `PHP_INT_MAX` (after) | other plugin → Kustom | **kept, order refunded** | 1 POST to Kustom `/refunds` |

The "before" row reproduces the reported symptom exactly: money refunded at Kustom, record discarded by WooCommerce.

Also confirmed:

- **No double refund.** Zero requests to any Klarna host in either state — the other plugin's handler bails on its payment-method check long before reaching its own API.
- **Existing guard untouched.** With the separate Klarna Order Management plugin active, the `class_exists( 'WC_Klarna_Order_Management' )` guard still defers correctly (our handler never registers) and refunds work in that combination.
- Partial refunds and repeat refunds on the same order behave correctly.

## Notes

- Stores already running a version of the other plugin that removed its conflicting registration are unaffected; this change means the problem can't recur from any other plugin on the same filter.
- Third parties can no longer override our refund result at a priority above 10. The filter has no hook documentation, so this is treated as acceptable.

https://app.clickup.com/t/2423261/869ed5w3w
