### PR TITLE
Recognise Kustom Shipping Assistant rates with an instance suffix

### DIFF
--- a/.changelogs/2026-09-07-ksa-shipping-rate-id-guard
+++ b/.changelogs/2026-09-07-ksa-shipping-rate-id-guard
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed an issue where the customer could see a "shipping methods have been changed" error when placing an order with Kustom Shipping Assistant handling the shipping selection.

--- a/classes/class-kco-checkout.php
+++ b/classes/class-kco-checkout.php
@@ -167,8 +167,8 @@ class KCO_Checkout {
 			return $default;
 		}
 
-		// The Kustom Shipping Service sets the chosen shipping method to the method without the instance ID, so if $chosen method === 'klarna_kss' return $default.
-		if ( 'klarna_kss' === $chosen_method ) {
+		// Kustom Shipping Assistant owns the shipping method, so leave the assessment to it. Match on the method ID, which may or may not carry an instance suffix ('klarna_kss:1') depending on the plugin version.
+		if ( 'klarna_kss' === $chosen_method || 0 === strpos( $chosen_method, 'klarna_kss:' ) ) {
 			return $default;
 		}
 

--- a/classes/class-kco-checkout.php
+++ b/classes/class-kco-checkout.php
@@ -167,7 +167,7 @@ class KCO_Checkout {
 			return $default;
 		}
 
-		// Kustom Shipping Assistant owns the shipping method, so leave the assessment to it. Match on the method ID, which may or may not carry an instance suffix ('klarna_kss:1') depending on the plugin version.
+		// Kustom Shipping Assistant owns the shipping method, so leave the assessment to it. The chosen value is a rate ID, which older versions of that plugin set to the bare method ID and newer ones to 'klarna_kss:<instance>'.
 		if ( 'klarna_kss' === $chosen_method || 0 === strpos( $chosen_method, 'klarna_kss:' ) ) {
 			return $default;
 		}

--- a/tests/Integration/CheckoutTest.php
+++ b/tests/Integration/CheckoutTest.php
@@ -281,8 +281,10 @@ class CheckoutTest extends IntegrationTestCase {
 
 		WC()->session->set( 'chosen_payment_method', 'kco' );
 
-		$this->checkoutProcessCount = $GLOBALS['wp_actions']['woocommerce_checkout_process'] ?? 0;
-		do_action( 'woocommerce_checkout_process' );
+		// The guard only reads the count, so raise it rather than firing the action and
+		// running whatever a plugin has hooked to it.
+		$this->checkoutProcessCount                            = $GLOBALS['wp_actions']['woocommerce_checkout_process'] ?? 0;
+		$GLOBALS['wp_actions']['woocommerce_checkout_process'] = $this->checkoutProcessCount + 1;
 	}
 
 	private function arrangeFailure( string $scenario ): \WC_Order {

--- a/tests/Integration/CheckoutTest.php
+++ b/tests/Integration/CheckoutTest.php
@@ -12,19 +12,35 @@ use Tests\Support\IntegrationTestCase;
 
 /**
  * The checkout entry point. Which flow handles a purchase, what each one stamps on
- * the order, and what it hands back to WooCommerce.
+ * the order, what it hands back to WooCommerce, and how it reads the shipping
+ * selection it is handed.
  *
  * @covers \Krokedil\KustomCheckout\CheckoutFlow\CheckoutFlow
  * @covers \KCO_Gateway::process_payment
+ * @covers \KCO_Checkout::maybe_register_shipping_error
  */
 class CheckoutTest extends IntegrationTestCase {
 
 	protected ?string $storeProfile = 'se';
 
+	/** The `woocommerce_checkout_process` count from before the shipping fixture raised it. */
+	private ?int $checkoutProcessCount = null;
+
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->haveCustomerAddress( $this->swedishAddress(), $this->swedishAddress() );
+	}
+
+	protected function tearDown(): void {
+		// did_action() counts never fall, and the assessment's first guard reads this one,
+		// so leaving it raised would arm the guard for every later test in the process.
+		if ( null !== $this->checkoutProcessCount ) {
+			$GLOBALS['wp_actions']['woocommerce_checkout_process'] = $this->checkoutProcessCount;
+			$this->checkoutProcessCount                            = null;
+		}
+
+		parent::tearDown();
 	}
 
 	/**
@@ -224,6 +240,49 @@ class CheckoutTest extends IntegrationTestCase {
 		$this->expectExceptionMessage( 'Invalid order ID.' );
 
 		$this->gateway()->process_payment( 999999999 );
+	}
+
+	/**
+	 * WooCommerce quietly swaps the chosen shipping method when it stops recognising it,
+	 * and the plugin turns that into an error the customer can act on. Kustom Shipping
+	 * Assistant owns the selection itself, so its rate must never be read as a swap.
+	 *
+	 * @dataProvider provide_shipping_selections
+	 */
+	public function test_a_shipping_selection_the_plugin_does_not_own_is_left_alone( string $chosen, string $default ): void {
+		$this->arrangeShippingAssessment();
+
+		$before = did_action( 'kco_checkout_shipping_error' );
+
+		$this->assertSame( $default, apply_filters( 'woocommerce_shipping_chosen_method', $default, [], $chosen ) );
+		$this->assertSame(
+			$before,
+			did_action( 'kco_checkout_shipping_error' ),
+			sprintf( 'A chosen method of "%s" must not register a shipping error.', $chosen )
+		);
+	}
+
+	/** @return array<string, array{0: string, 1: string}> */
+	public function provide_shipping_selections(): array {
+		return [
+			'the shipping assistant rate, carrying its zone instance' => [ 'klarna_kss:1', 'flat_rate:1' ],
+			'the shipping assistant method, carrying none'            => [ 'klarna_kss', 'flat_rate:1' ],
+			'a method WooCommerce did not swap'                       => [ 'flat_rate:1', 'flat_rate:1' ],
+		];
+	}
+
+	/**
+	 * The assessment only runs part way through a Kustom checkout that has the shipping
+	 * options inside the iframe.
+	 */
+	private function arrangeShippingAssessment(): void {
+		$this->haveGatewayCredentials( 'eu', [ 'shipping_methods_in_iframe' => 'yes' ] );
+		$this->flushGatewaySettingsCache();
+
+		WC()->session->set( 'chosen_payment_method', 'kco' );
+
+		$this->checkoutProcessCount = $GLOBALS['wp_actions']['woocommerce_checkout_process'] ?? 0;
+		do_action( 'woocommerce_checkout_process' );
 	}
 
 	private function arrangeFailure( string $scenario ): \WC_Order {

--- a/tests/Support/Traits/CanConfigureStore.php
+++ b/tests/Support/Traits/CanConfigureStore.php
@@ -275,7 +275,7 @@ trait CanConfigureStore {
 
 	/** Forgets the gateway state the WooCommerce session carries between requests. */
 	protected function resetGatewaySession(): void {
-		foreach ( [ 'kco_wc_order_id', 'kco_update_md5', 'kco_shipping_data', 'kco_wc_prefill_consent' ] as $key ) {
+		foreach ( [ 'kco_wc_order_id', 'kco_update_md5', 'kco_shipping_data', 'kco_wc_prefill_consent', 'chosen_payment_method' ] as $key ) {
 			WC()->session->__unset( $key );
 		}
 	}


### PR DESCRIPTION
`KCO_Checkout::maybe_register_shipping_error()` matched the chosen shipping method against the bare 'klarna_kss' method ID. Kustom Shipping Assistant's method is zone-instantiated, so its rate ID carries an instance suffix ('klarna_kss:1'), and once KSA sets that as the chosen method the assessment no longer recognised it as Kustom-owned.

Match on the method ID instead, accepting both the suffixed and unsuffixed forms so older Kustom Shipping Assistant versions keep working.

https://app.clickup.com/t/2423261/869ey84bh